### PR TITLE
Add group and user controllers

### DIFF
--- a/src/main/java/com/ahumadamob/todolist/controller/GroupController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/GroupController.java
@@ -18,6 +18,7 @@ import com.ahumadamob.todolist.dto.ErrorResponseDto;
 import com.ahumadamob.todolist.dto.SuccessResponseDto;
 import com.ahumadamob.todolist.entity.Group;
 import com.ahumadamob.todolist.service.IGroupService;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import jakarta.validation.Valid;
 
@@ -26,6 +27,7 @@ import jakarta.validation.Valid;
 public class GroupController {
     private final IGroupService groupService;
 
+    @Autowired
     public GroupController(IGroupService groupService) {
         this.groupService = groupService;
     }

--- a/src/main/java/com/ahumadamob/todolist/controller/GroupController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/GroupController.java
@@ -1,0 +1,72 @@
+package com.ahumadamob.todolist.controller;
+
+import java.util.List;
+import java.util.Collections;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ahumadamob.todolist.dto.ErrorResponseDto;
+import com.ahumadamob.todolist.dto.SuccessResponseDto;
+import com.ahumadamob.todolist.entity.Group;
+import com.ahumadamob.todolist.service.IGroupService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/groups")
+public class GroupController {
+    private final IGroupService groupService;
+
+    public GroupController(IGroupService groupService) {
+        this.groupService = groupService;
+    }
+
+    @GetMapping
+    public ResponseEntity<SuccessResponseDto<List<Group>>> findAll() {
+        List<Group> groups = groupService.findAll();
+        return ResponseEntity.ok(new SuccessResponseDto<>("Groups retrieved", groups));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> findById(@PathVariable Long id) {
+        Group group = groupService.findById(id);
+        if (group == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ErrorResponseDto(Collections.singletonList("Group not found")));
+        }
+        return ResponseEntity.ok(new SuccessResponseDto<>("Group found", group));
+    }
+
+    @PostMapping
+    public ResponseEntity<SuccessResponseDto<Group>> create(@Valid @RequestBody Group group) {
+        Group saved = groupService.save(group);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new SuccessResponseDto<>("Group created", saved));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> update(@PathVariable Long id, @Valid @RequestBody Group group) {
+        if (groupService.findById(id) == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ErrorResponseDto(Collections.singletonList("Group not found")));
+        }
+        group.setId(id);
+        Group saved = groupService.save(group);
+        return ResponseEntity.ok(new SuccessResponseDto<>("Group updated", saved));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<SuccessResponseDto<Void>> delete(@PathVariable Long id) {
+        groupService.deleteById(id);
+        return ResponseEntity.ok(new SuccessResponseDto<>("Group deleted", null));
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/controller/UserController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/UserController.java
@@ -18,6 +18,7 @@ import com.ahumadamob.todolist.dto.ErrorResponseDto;
 import com.ahumadamob.todolist.dto.SuccessResponseDto;
 import com.ahumadamob.todolist.entity.User;
 import com.ahumadamob.todolist.service.IUserService;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import jakarta.validation.Valid;
 
@@ -26,6 +27,7 @@ import jakarta.validation.Valid;
 public class UserController {
     private final IUserService userService;
 
+    @Autowired
     public UserController(IUserService userService) {
         this.userService = userService;
     }

--- a/src/main/java/com/ahumadamob/todolist/controller/UserController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/UserController.java
@@ -1,0 +1,72 @@
+package com.ahumadamob.todolist.controller;
+
+import java.util.List;
+import java.util.Collections;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ahumadamob.todolist.dto.ErrorResponseDto;
+import com.ahumadamob.todolist.dto.SuccessResponseDto;
+import com.ahumadamob.todolist.entity.User;
+import com.ahumadamob.todolist.service.IUserService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+    private final IUserService userService;
+
+    public UserController(IUserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping
+    public ResponseEntity<SuccessResponseDto<List<User>>> findAll() {
+        List<User> users = userService.findAll();
+        return ResponseEntity.ok(new SuccessResponseDto<>("Users retrieved", users));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> findById(@PathVariable Long id) {
+        User user = userService.findById(id);
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ErrorResponseDto(Collections.singletonList("User not found")));
+        }
+        return ResponseEntity.ok(new SuccessResponseDto<>("User found", user));
+    }
+
+    @PostMapping
+    public ResponseEntity<SuccessResponseDto<User>> create(@Valid @RequestBody User user) {
+        User saved = userService.save(user);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new SuccessResponseDto<>("User created", saved));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> update(@PathVariable Long id, @Valid @RequestBody User user) {
+        if (userService.findById(id) == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ErrorResponseDto(Collections.singletonList("User not found")));
+        }
+        user.setId(id);
+        User saved = userService.save(user);
+        return ResponseEntity.ok(new SuccessResponseDto<>("User updated", saved));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<SuccessResponseDto<Void>> delete(@PathVariable Long id) {
+        userService.deleteById(id);
+        return ResponseEntity.ok(new SuccessResponseDto<>("User deleted", null));
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/entity/Group.java
+++ b/src/main/java/com/ahumadamob/todolist/entity/Group.java
@@ -1,0 +1,22 @@
+package com.ahumadamob.todolist.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.Data;
+import java.util.List;
+
+@Entity
+@Data
+public class Group {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "group")
+    private List<User> users;
+}

--- a/src/main/java/com/ahumadamob/todolist/entity/User.java
+++ b/src/main/java/com/ahumadamob/todolist/entity/User.java
@@ -1,0 +1,23 @@
+package com.ahumadamob.todolist.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Data;
+
+@Entity
+@Data
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    @ManyToOne
+    @JoinColumn(name = "group_id")
+    private Group group;
+}

--- a/src/main/java/com/ahumadamob/todolist/repository/GroupRepository.java
+++ b/src/main/java/com/ahumadamob/todolist/repository/GroupRepository.java
@@ -1,0 +1,7 @@
+package com.ahumadamob.todolist.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.ahumadamob.todolist.entity.Group;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+}

--- a/src/main/java/com/ahumadamob/todolist/repository/UserRepository.java
+++ b/src/main/java/com/ahumadamob/todolist/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.ahumadamob.todolist.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.ahumadamob.todolist.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/ahumadamob/todolist/service/IGroupService.java
+++ b/src/main/java/com/ahumadamob/todolist/service/IGroupService.java
@@ -1,0 +1,11 @@
+package com.ahumadamob.todolist.service;
+
+import java.util.List;
+import com.ahumadamob.todolist.entity.Group;
+
+public interface IGroupService {
+    Group save(Group group);
+    List<Group> findAll();
+    Group findById(Long id);
+    void deleteById(Long id);
+}

--- a/src/main/java/com/ahumadamob/todolist/service/IUserService.java
+++ b/src/main/java/com/ahumadamob/todolist/service/IUserService.java
@@ -1,0 +1,11 @@
+package com.ahumadamob.todolist.service;
+
+import java.util.List;
+import com.ahumadamob.todolist.entity.User;
+
+public interface IUserService {
+    User save(User user);
+    List<User> findAll();
+    User findById(Long id);
+    void deleteById(Long id);
+}

--- a/src/main/java/com/ahumadamob/todolist/service/jpa/GroupServiceJpa.java
+++ b/src/main/java/com/ahumadamob/todolist/service/jpa/GroupServiceJpa.java
@@ -5,12 +5,14 @@ import org.springframework.stereotype.Service;
 import com.ahumadamob.todolist.entity.Group;
 import com.ahumadamob.todolist.repository.GroupRepository;
 import com.ahumadamob.todolist.service.IGroupService;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Service
 public class GroupServiceJpa implements IGroupService {
 
     private final GroupRepository groupRepository;
 
+    @Autowired
     public GroupServiceJpa(GroupRepository groupRepository) {
         this.groupRepository = groupRepository;
     }

--- a/src/main/java/com/ahumadamob/todolist/service/jpa/GroupServiceJpa.java
+++ b/src/main/java/com/ahumadamob/todolist/service/jpa/GroupServiceJpa.java
@@ -1,0 +1,37 @@
+package com.ahumadamob.todolist.service.jpa;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import com.ahumadamob.todolist.entity.Group;
+import com.ahumadamob.todolist.repository.GroupRepository;
+import com.ahumadamob.todolist.service.IGroupService;
+
+@Service
+public class GroupServiceJpa implements IGroupService {
+
+    private final GroupRepository groupRepository;
+
+    public GroupServiceJpa(GroupRepository groupRepository) {
+        this.groupRepository = groupRepository;
+    }
+
+    @Override
+    public Group save(Group group) {
+        return groupRepository.save(group);
+    }
+
+    @Override
+    public List<Group> findAll() {
+        return groupRepository.findAll();
+    }
+
+    @Override
+    public Group findById(Long id) {
+        return groupRepository.findById(id).orElse(null);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        groupRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/service/jpa/UserServiceJpa.java
+++ b/src/main/java/com/ahumadamob/todolist/service/jpa/UserServiceJpa.java
@@ -1,0 +1,37 @@
+package com.ahumadamob.todolist.service.jpa;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import com.ahumadamob.todolist.entity.User;
+import com.ahumadamob.todolist.repository.UserRepository;
+import com.ahumadamob.todolist.service.IUserService;
+
+@Service
+public class UserServiceJpa implements IUserService {
+
+    private final UserRepository userRepository;
+
+    public UserServiceJpa(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public User save(User user) {
+        return userRepository.save(user);
+    }
+
+    @Override
+    public List<User> findAll() {
+        return userRepository.findAll();
+    }
+
+    @Override
+    public User findById(Long id) {
+        return userRepository.findById(id).orElse(null);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        userRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/service/jpa/UserServiceJpa.java
+++ b/src/main/java/com/ahumadamob/todolist/service/jpa/UserServiceJpa.java
@@ -5,12 +5,14 @@ import org.springframework.stereotype.Service;
 import com.ahumadamob.todolist.entity.User;
 import com.ahumadamob.todolist.repository.UserRepository;
 import com.ahumadamob.todolist.service.IUserService;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Service
 public class UserServiceJpa implements IUserService {
 
     private final UserRepository userRepository;
 
+    @Autowired
     public UserServiceJpa(UserRepository userRepository) {
         this.userRepository = userRepository;
     }


### PR DESCRIPTION
## Summary
- implement `GroupController` under `/groups`
- implement `UserController` under `/users`
- both controllers use existing service layer with `save` for create/update
- return `SuccessResponseDto` or `ErrorResponseDto` in responses

## Testing
- `./mvnw -q test` *(fails: cannot fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_6844c0c71ba0832f936b7d0f2d73b467