### PR TITLE
Add separate create and update methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,6 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -63,27 +58,13 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<annotationProcessorPaths>
-						<path>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</path>
-					</annotationProcessorPaths>
-				</configuration>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
 			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/com/ahumadamob/todolist/controller/GroupController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/GroupController.java
@@ -1,0 +1,75 @@
+package com.ahumadamob.todolist.controller;
+
+import java.util.List;
+import java.util.Collections;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ahumadamob.todolist.dto.ErrorResponseDto;
+import com.ahumadamob.todolist.dto.SuccessResponseDto;
+import com.ahumadamob.todolist.entity.Group;
+import com.ahumadamob.todolist.service.IGroupService;
+import com.ahumadamob.todolist.exception.RecordNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/groups")
+public class GroupController {
+    private final IGroupService groupService;
+
+    @Autowired
+    public GroupController(IGroupService groupService) {
+        this.groupService = groupService;
+    }
+
+    @GetMapping
+    public ResponseEntity<SuccessResponseDto<List<Group>>> findAll() {
+        List<Group> groups = groupService.findAll();
+        return ResponseEntity.ok(new SuccessResponseDto<>("Groups retrieved", groups));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> findById(@PathVariable Long id) {
+        Group group = groupService.findById(id);
+        if (group == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ErrorResponseDto(Collections.singletonList("Group not found")));
+        }
+        return ResponseEntity.ok(new SuccessResponseDto<>("Group found", group));
+    }
+
+    @PostMapping
+    public ResponseEntity<SuccessResponseDto<Group>> create(@Valid @RequestBody Group group) {
+        Group saved = groupService.create(group);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new SuccessResponseDto<>("Group created", saved));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> update(@PathVariable Long id, @Valid @RequestBody Group group) {
+        try {
+            Group saved = groupService.update(id, group);
+            return ResponseEntity.ok(new SuccessResponseDto<>("Group updated", saved));
+        } catch (RecordNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ErrorResponseDto(Collections.singletonList(e.getMessage())));
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<SuccessResponseDto<Void>> delete(@PathVariable Long id) {
+        groupService.deleteById(id);
+        return ResponseEntity.ok(new SuccessResponseDto<>("Group deleted", null));
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/controller/GroupController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/GroupController.java
@@ -18,7 +18,6 @@ import com.ahumadamob.todolist.dto.ErrorResponseDto;
 import com.ahumadamob.todolist.dto.SuccessResponseDto;
 import com.ahumadamob.todolist.entity.Group;
 import com.ahumadamob.todolist.service.IGroupService;
-import com.ahumadamob.todolist.exception.RecordNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import jakarta.validation.Valid;
@@ -53,14 +52,9 @@ public class GroupController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<?> update(@PathVariable Long id, @Valid @RequestBody Group group) {
-        try {
-            Group saved = groupService.update(id, group);
-            return ResponseEntity.ok(new SuccessResponseDto<>("Group updated", saved));
-        } catch (RecordNotFoundException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new ErrorResponseDto(Collections.singletonList(e.getMessage())));
-        }
+    public ResponseEntity<SuccessResponseDto<Group>> update(@PathVariable Long id, @Valid @RequestBody Group group) {
+        Group saved = groupService.update(id, group);
+        return ResponseEntity.ok(new SuccessResponseDto<>("Group updated", saved));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/ahumadamob/todolist/controller/GroupController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/GroupController.java
@@ -20,6 +20,7 @@ import com.ahumadamob.todolist.dto.GroupRequestDto;
 import com.ahumadamob.todolist.dto.GroupResponseDto;
 import com.ahumadamob.todolist.entity.Group;
 import com.ahumadamob.todolist.service.IGroupService;
+import com.ahumadamob.todolist.mapper.GroupMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import jakarta.validation.Valid;
@@ -30,11 +31,14 @@ public class GroupController {
     @Autowired
     private IGroupService groupService;
 
+    @Autowired
+    private GroupMapper groupMapper;
+
     @GetMapping
     public ResponseEntity<SuccessResponseDto<List<GroupResponseDto>>> findAll() {
         List<Group> groups = groupService.findAll();
         List<GroupResponseDto> dtos = groups.stream()
-                .map(this::toDto)
+                .map(groupMapper::toDto)
                 .toList();
         return ResponseEntity.ok(new SuccessResponseDto<>("Groups retrieved", dtos));
     }
@@ -46,22 +50,20 @@ public class GroupController {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(new ErrorResponseDto(Collections.singletonList("Group not found")));
         }
-        return ResponseEntity.ok(new SuccessResponseDto<>("Group found", toDto(group)));
+        return ResponseEntity.ok(new SuccessResponseDto<>("Group found", groupMapper.toDto(group)));
     }
 
     @PostMapping
     public ResponseEntity<SuccessResponseDto<GroupResponseDto>> create(@Valid @RequestBody GroupRequestDto dto) {
-        Group group = toEntity(dto);
-        Group saved = groupService.create(group);
+        Group saved = groupService.create(dto);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new SuccessResponseDto<>("Group created", toDto(saved)));
+                .body(new SuccessResponseDto<>("Group created", groupMapper.toDto(saved)));
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<SuccessResponseDto<GroupResponseDto>> update(@PathVariable Long id, @Valid @RequestBody GroupRequestDto dto) {
-        Group group = toEntity(dto);
-        Group saved = groupService.update(id, group);
-        return ResponseEntity.ok(new SuccessResponseDto<>("Group updated", toDto(saved)));
+        Group saved = groupService.update(id, dto);
+        return ResponseEntity.ok(new SuccessResponseDto<>("Group updated", groupMapper.toDto(saved)));
     }
 
     @DeleteMapping("/{id}")
@@ -70,13 +72,4 @@ public class GroupController {
         return ResponseEntity.ok(new SuccessResponseDto<>("Group deleted", null));
     }
 
-    private GroupResponseDto toDto(Group group) {
-        return new GroupResponseDto(group.getId(), group.getName());
-    }
-
-    private Group toEntity(GroupRequestDto dto) {
-        Group group = new Group();
-        group.setName(dto.getName());
-        return group;
-    }
 }

--- a/src/main/java/com/ahumadamob/todolist/controller/GroupController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/GroupController.java
@@ -26,12 +26,8 @@ import jakarta.validation.Valid;
 @RestController
 @RequestMapping("/groups")
 public class GroupController {
-    private final IGroupService groupService;
-
     @Autowired
-    public GroupController(IGroupService groupService) {
-        this.groupService = groupService;
-    }
+    private IGroupService groupService;
 
     @GetMapping
     public ResponseEntity<SuccessResponseDto<List<Group>>> findAll() {

--- a/src/main/java/com/ahumadamob/todolist/controller/UserController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/UserController.java
@@ -1,0 +1,75 @@
+package com.ahumadamob.todolist.controller;
+
+import java.util.List;
+import java.util.Collections;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ahumadamob.todolist.dto.ErrorResponseDto;
+import com.ahumadamob.todolist.dto.SuccessResponseDto;
+import com.ahumadamob.todolist.entity.User;
+import com.ahumadamob.todolist.service.IUserService;
+import com.ahumadamob.todolist.exception.RecordNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+    private final IUserService userService;
+
+    @Autowired
+    public UserController(IUserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping
+    public ResponseEntity<SuccessResponseDto<List<User>>> findAll() {
+        List<User> users = userService.findAll();
+        return ResponseEntity.ok(new SuccessResponseDto<>("Users retrieved", users));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> findById(@PathVariable Long id) {
+        User user = userService.findById(id);
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ErrorResponseDto(Collections.singletonList("User not found")));
+        }
+        return ResponseEntity.ok(new SuccessResponseDto<>("User found", user));
+    }
+
+    @PostMapping
+    public ResponseEntity<SuccessResponseDto<User>> create(@Valid @RequestBody User user) {
+        User saved = userService.create(user);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new SuccessResponseDto<>("User created", saved));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> update(@PathVariable Long id, @Valid @RequestBody User user) {
+        try {
+            User saved = userService.update(id, user);
+            return ResponseEntity.ok(new SuccessResponseDto<>("User updated", saved));
+        } catch (RecordNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ErrorResponseDto(Collections.singletonList(e.getMessage())));
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<SuccessResponseDto<Void>> delete(@PathVariable Long id) {
+        userService.deleteById(id);
+        return ResponseEntity.ok(new SuccessResponseDto<>("User deleted", null));
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/controller/UserController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/UserController.java
@@ -26,12 +26,8 @@ import jakarta.validation.Valid;
 @RestController
 @RequestMapping("/users")
 public class UserController {
-    private final IUserService userService;
-
     @Autowired
-    public UserController(IUserService userService) {
-        this.userService = userService;
-    }
+    private IUserService userService;
 
     @GetMapping
     public ResponseEntity<SuccessResponseDto<List<User>>> findAll() {

--- a/src/main/java/com/ahumadamob/todolist/controller/UserController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/UserController.java
@@ -18,7 +18,6 @@ import com.ahumadamob.todolist.dto.ErrorResponseDto;
 import com.ahumadamob.todolist.dto.SuccessResponseDto;
 import com.ahumadamob.todolist.entity.User;
 import com.ahumadamob.todolist.service.IUserService;
-import com.ahumadamob.todolist.exception.RecordNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import jakarta.validation.Valid;
@@ -53,14 +52,9 @@ public class UserController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<?> update(@PathVariable Long id, @Valid @RequestBody User user) {
-        try {
-            User saved = userService.update(id, user);
-            return ResponseEntity.ok(new SuccessResponseDto<>("User updated", saved));
-        } catch (RecordNotFoundException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new ErrorResponseDto(Collections.singletonList(e.getMessage())));
-        }
+    public ResponseEntity<SuccessResponseDto<User>> update(@PathVariable Long id, @Valid @RequestBody User user) {
+        User saved = userService.update(id, user);
+        return ResponseEntity.ok(new SuccessResponseDto<>("User updated", saved));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/ahumadamob/todolist/dto/ErrorResponseDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/ErrorResponseDto.java
@@ -1,13 +1,25 @@
 package com.ahumadamob.todolist.dto;
 
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
+/**
+ * Simple DTO representing an error response with a list of messages.
+ */
 public class ErrorResponseDto {
     private List<String> messages;
+
+    public ErrorResponseDto() {
+    }
+
+    public ErrorResponseDto(List<String> messages) {
+        this.messages = messages;
+    }
+
+    public List<String> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(List<String> messages) {
+        this.messages = messages;
+    }
 }

--- a/src/main/java/com/ahumadamob/todolist/dto/GroupRequestDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/GroupRequestDto.java
@@ -1,0 +1,23 @@
+package com.ahumadamob.todolist.dto;
+
+/**
+ * DTO utilizado para crear o actualizar un grupo.
+ */
+public class GroupRequestDto {
+    private String name;
+
+    public GroupRequestDto() {
+    }
+
+    public GroupRequestDto(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/dto/GroupResponseDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/GroupResponseDto.java
@@ -1,0 +1,33 @@
+package com.ahumadamob.todolist.dto;
+
+/**
+ * DTO enviado al cliente para representar un grupo.
+ */
+public class GroupResponseDto {
+    private Long id;
+    private String name;
+
+    public GroupResponseDto() {
+    }
+
+    public GroupResponseDto(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/dto/SuccessResponseDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/SuccessResponseDto.java
@@ -1,13 +1,34 @@
 package com.ahumadamob.todolist.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
+/**
+ * Wrapper used to send a successful operation result to the client.
+ */
 public class SuccessResponseDto<T> {
     private String message;
     private T data;
+
+    public SuccessResponseDto() {
+    }
+
+    public SuccessResponseDto(String message, T data) {
+        this.message = message;
+        this.data = data;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
 }

--- a/src/main/java/com/ahumadamob/todolist/dto/UserRequestDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/UserRequestDto.java
@@ -1,0 +1,44 @@
+package com.ahumadamob.todolist.dto;
+
+/**
+ * DTO utilizado para crear o actualizar un usuario. Se
+ * indica el id del grupo asociado.
+ */
+public class UserRequestDto {
+    private String username;
+    private String password;
+    private Long groupId;
+
+    public UserRequestDto() {
+    }
+
+    public UserRequestDto(String username, String password, Long groupId) {
+        this.username = username;
+        this.password = password;
+        this.groupId = groupId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public Long getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(Long groupId) {
+        this.groupId = groupId;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/dto/UserResponseDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/UserResponseDto.java
@@ -1,0 +1,44 @@
+package com.ahumadamob.todolist.dto;
+
+/**
+ * DTO enviado al cliente para representar un usuario.
+ * No expone el campo de contraseña.
+ */
+public class UserResponseDto {
+    private Long id;
+    private String username;
+    private GroupResponseDto group;
+
+    public UserResponseDto() {
+    }
+
+    public UserResponseDto(Long id, String username, GroupResponseDto group) {
+        this.id = id;
+        this.username = username;
+        this.group = group;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public GroupResponseDto getGroup() {
+        return group;
+    }
+
+    public void setGroup(GroupResponseDto group) {
+        this.group = group;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/entity/Group.java
+++ b/src/main/java/com/ahumadamob/todolist/entity/Group.java
@@ -5,11 +5,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import lombok.Data;
 import java.util.List;
 
 @Entity
-@Data
 public class Group {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -19,4 +17,37 @@ public class Group {
 
     @OneToMany(mappedBy = "group")
     private List<User> users;
+
+    public Group() {
+    }
+
+    public Group(Long id, String name, List<User> users) {
+        this.id = id;
+        this.name = name;
+        this.users = users;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<User> getUsers() {
+        return users;
+    }
+
+    public void setUsers(List<User> users) {
+        this.users = users;
+    }
 }

--- a/src/main/java/com/ahumadamob/todolist/entity/Group.java
+++ b/src/main/java/com/ahumadamob/todolist/entity/Group.java
@@ -1,0 +1,22 @@
+package com.ahumadamob.todolist.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.Data;
+import java.util.List;
+
+@Entity
+@Data
+public class Group {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "group")
+    private List<User> users;
+}

--- a/src/main/java/com/ahumadamob/todolist/entity/User.java
+++ b/src/main/java/com/ahumadamob/todolist/entity/User.java
@@ -6,10 +6,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.Data;
-
 @Entity
-@Data
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -20,4 +17,37 @@ public class User {
     @ManyToOne
     @JoinColumn(name = "group_id")
     private Group group;
+
+    public User() {
+    }
+
+    public User(Long id, String username, Group group) {
+        this.id = id;
+        this.username = username;
+        this.group = group;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public Group getGroup() {
+        return group;
+    }
+
+    public void setGroup(Group group) {
+        this.group = group;
+    }
 }

--- a/src/main/java/com/ahumadamob/todolist/entity/User.java
+++ b/src/main/java/com/ahumadamob/todolist/entity/User.java
@@ -1,0 +1,23 @@
+package com.ahumadamob.todolist.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Data;
+
+@Entity
+@Data
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    @ManyToOne
+    @JoinColumn(name = "group_id")
+    private Group group;
+}

--- a/src/main/java/com/ahumadamob/todolist/entity/User.java
+++ b/src/main/java/com/ahumadamob/todolist/entity/User.java
@@ -14,6 +14,8 @@ public class User {
 
     private String username;
 
+    private String password;
+
     @ManyToOne
     @JoinColumn(name = "group_id")
     private Group group;
@@ -21,9 +23,10 @@ public class User {
     public User() {
     }
 
-    public User(Long id, String username, Group group) {
+    public User(Long id, String username, String password, Group group) {
         this.id = id;
         this.username = username;
+        this.password = password;
         this.group = group;
     }
 
@@ -41,6 +44,14 @@ public class User {
 
     public void setUsername(String username) {
         this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
     }
 
     public Group getGroup() {

--- a/src/main/java/com/ahumadamob/todolist/exception/RecordNotFoundException.java
+++ b/src/main/java/com/ahumadamob/todolist/exception/RecordNotFoundException.java
@@ -1,0 +1,7 @@
+package com.ahumadamob.todolist.exception;
+
+public class RecordNotFoundException extends RuntimeException {
+    public RecordNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/exception/RestExceptionHandler.java
+++ b/src/main/java/com/ahumadamob/todolist/exception/RestExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.ahumadamob.todolist.exception;
+
+import java.util.Collections;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.ahumadamob.todolist.dto.ErrorResponseDto;
+
+@RestControllerAdvice
+public class RestExceptionHandler {
+
+    @ExceptionHandler(RecordNotFoundException.class)
+    public ResponseEntity<ErrorResponseDto> handleRecordNotFound(RecordNotFoundException ex) {
+        ErrorResponseDto dto = new ErrorResponseDto(Collections.singletonList(ex.getMessage()));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(dto);
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/mapper/GroupMapper.java
+++ b/src/main/java/com/ahumadamob/todolist/mapper/GroupMapper.java
@@ -1,0 +1,25 @@
+package com.ahumadamob.todolist.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.ahumadamob.todolist.dto.GroupRequestDto;
+import com.ahumadamob.todolist.dto.GroupResponseDto;
+import com.ahumadamob.todolist.entity.Group;
+
+@Component
+public class GroupMapper {
+
+    public Group toEntity(GroupRequestDto dto) {
+        Group group = new Group();
+        applyToEntity(dto, group);
+        return group;
+    }
+
+    public void applyToEntity(GroupRequestDto dto, Group group) {
+        group.setName(dto.getName());
+    }
+
+    public GroupResponseDto toDto(Group group) {
+        return new GroupResponseDto(group.getId(), group.getName());
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/mapper/UserMapper.java
+++ b/src/main/java/com/ahumadamob/todolist/mapper/UserMapper.java
@@ -1,0 +1,46 @@
+package com.ahumadamob.todolist.mapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.ahumadamob.todolist.dto.GroupResponseDto;
+import com.ahumadamob.todolist.dto.UserRequestDto;
+import com.ahumadamob.todolist.dto.UserResponseDto;
+import com.ahumadamob.todolist.entity.Group;
+import com.ahumadamob.todolist.entity.User;
+import com.ahumadamob.todolist.exception.RecordNotFoundException;
+import com.ahumadamob.todolist.repository.GroupRepository;
+
+@Component
+public class UserMapper {
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    public User toEntity(UserRequestDto dto) {
+        User user = new User();
+        applyToEntity(dto, user);
+        return user;
+    }
+
+    public void applyToEntity(UserRequestDto dto, User user) {
+        user.setUsername(dto.getUsername());
+        user.setPassword(dto.getPassword());
+
+        if (dto.getGroupId() != null) {
+            Group group = groupRepository.findById(dto.getGroupId())
+                    .orElseThrow(() -> new RecordNotFoundException("Group not found"));
+            user.setGroup(group);
+        } else {
+            user.setGroup(null);
+        }
+    }
+
+    public UserResponseDto toDto(User user) {
+        GroupResponseDto groupDto = null;
+        if (user.getGroup() != null) {
+            groupDto = new GroupResponseDto(user.getGroup().getId(), user.getGroup().getName());
+        }
+        return new UserResponseDto(user.getId(), user.getUsername(), groupDto);
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/repository/GroupRepository.java
+++ b/src/main/java/com/ahumadamob/todolist/repository/GroupRepository.java
@@ -1,0 +1,7 @@
+package com.ahumadamob.todolist.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.ahumadamob.todolist.entity.Group;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+}

--- a/src/main/java/com/ahumadamob/todolist/repository/UserRepository.java
+++ b/src/main/java/com/ahumadamob/todolist/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.ahumadamob.todolist.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.ahumadamob.todolist.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/ahumadamob/todolist/service/IGroupService.java
+++ b/src/main/java/com/ahumadamob/todolist/service/IGroupService.java
@@ -2,10 +2,11 @@ package com.ahumadamob.todolist.service;
 
 import java.util.List;
 import com.ahumadamob.todolist.entity.Group;
+import com.ahumadamob.todolist.dto.GroupRequestDto;
 
 public interface IGroupService {
-    Group create(Group group);
-    Group update(Long id, Group group);
+    Group create(GroupRequestDto dto);
+    Group update(Long id, GroupRequestDto dto);
     List<Group> findAll();
     Group findById(Long id);
     void deleteById(Long id);

--- a/src/main/java/com/ahumadamob/todolist/service/IGroupService.java
+++ b/src/main/java/com/ahumadamob/todolist/service/IGroupService.java
@@ -1,0 +1,12 @@
+package com.ahumadamob.todolist.service;
+
+import java.util.List;
+import com.ahumadamob.todolist.entity.Group;
+
+public interface IGroupService {
+    Group create(Group group);
+    Group update(Long id, Group group);
+    List<Group> findAll();
+    Group findById(Long id);
+    void deleteById(Long id);
+}

--- a/src/main/java/com/ahumadamob/todolist/service/IUserService.java
+++ b/src/main/java/com/ahumadamob/todolist/service/IUserService.java
@@ -1,0 +1,12 @@
+package com.ahumadamob.todolist.service;
+
+import java.util.List;
+import com.ahumadamob.todolist.entity.User;
+
+public interface IUserService {
+    User create(User user);
+    User update(Long id, User user);
+    List<User> findAll();
+    User findById(Long id);
+    void deleteById(Long id);
+}

--- a/src/main/java/com/ahumadamob/todolist/service/IUserService.java
+++ b/src/main/java/com/ahumadamob/todolist/service/IUserService.java
@@ -2,10 +2,11 @@ package com.ahumadamob.todolist.service;
 
 import java.util.List;
 import com.ahumadamob.todolist.entity.User;
+import com.ahumadamob.todolist.dto.UserRequestDto;
 
 public interface IUserService {
-    User create(User user);
-    User update(Long id, User user);
+    User create(UserRequestDto dto);
+    User update(Long id, UserRequestDto dto);
     List<User> findAll();
     User findById(Long id);
     void deleteById(Long id);

--- a/src/main/java/com/ahumadamob/todolist/service/jpa/GroupServiceJpa.java
+++ b/src/main/java/com/ahumadamob/todolist/service/jpa/GroupServiceJpa.java
@@ -11,12 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 @Service
 public class GroupServiceJpa implements IGroupService {
 
-    private final GroupRepository groupRepository;
-
     @Autowired
-    public GroupServiceJpa(GroupRepository groupRepository) {
-        this.groupRepository = groupRepository;
-    }
+    private GroupRepository groupRepository;
 
     @Override
     public Group create(Group group) {

--- a/src/main/java/com/ahumadamob/todolist/service/jpa/GroupServiceJpa.java
+++ b/src/main/java/com/ahumadamob/todolist/service/jpa/GroupServiceJpa.java
@@ -1,0 +1,48 @@
+package com.ahumadamob.todolist.service.jpa;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import com.ahumadamob.todolist.entity.Group;
+import com.ahumadamob.todolist.repository.GroupRepository;
+import com.ahumadamob.todolist.service.IGroupService;
+import com.ahumadamob.todolist.exception.RecordNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Service
+public class GroupServiceJpa implements IGroupService {
+
+    private final GroupRepository groupRepository;
+
+    @Autowired
+    public GroupServiceJpa(GroupRepository groupRepository) {
+        this.groupRepository = groupRepository;
+    }
+
+    @Override
+    public Group create(Group group) {
+        return groupRepository.save(group);
+    }
+
+    @Override
+    public Group update(Long id, Group group) {
+        Group existing = groupRepository.findById(id)
+                .orElseThrow(() -> new RecordNotFoundException("Group not found"));
+        group.setId(existing.getId());
+        return groupRepository.save(group);
+    }
+
+    @Override
+    public List<Group> findAll() {
+        return groupRepository.findAll();
+    }
+
+    @Override
+    public Group findById(Long id) {
+        return groupRepository.findById(id).orElse(null);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        groupRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/service/jpa/GroupServiceJpa.java
+++ b/src/main/java/com/ahumadamob/todolist/service/jpa/GroupServiceJpa.java
@@ -6,6 +6,8 @@ import com.ahumadamob.todolist.entity.Group;
 import com.ahumadamob.todolist.repository.GroupRepository;
 import com.ahumadamob.todolist.service.IGroupService;
 import com.ahumadamob.todolist.exception.RecordNotFoundException;
+import com.ahumadamob.todolist.dto.GroupRequestDto;
+import com.ahumadamob.todolist.mapper.GroupMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Service
@@ -14,17 +16,21 @@ public class GroupServiceJpa implements IGroupService {
     @Autowired
     private GroupRepository groupRepository;
 
+    @Autowired
+    private GroupMapper groupMapper;
+
     @Override
-    public Group create(Group group) {
+    public Group create(GroupRequestDto dto) {
+        Group group = groupMapper.toEntity(dto);
         return groupRepository.save(group);
     }
 
     @Override
-    public Group update(Long id, Group group) {
+    public Group update(Long id, GroupRequestDto dto) {
         Group existing = groupRepository.findById(id)
                 .orElseThrow(() -> new RecordNotFoundException("Group not found"));
-        group.setId(existing.getId());
-        return groupRepository.save(group);
+        groupMapper.applyToEntity(dto, existing);
+        return groupRepository.save(existing);
     }
 
     @Override

--- a/src/main/java/com/ahumadamob/todolist/service/jpa/UserServiceJpa.java
+++ b/src/main/java/com/ahumadamob/todolist/service/jpa/UserServiceJpa.java
@@ -6,6 +6,8 @@ import com.ahumadamob.todolist.entity.User;
 import com.ahumadamob.todolist.repository.UserRepository;
 import com.ahumadamob.todolist.service.IUserService;
 import com.ahumadamob.todolist.exception.RecordNotFoundException;
+import com.ahumadamob.todolist.dto.UserRequestDto;
+import com.ahumadamob.todolist.mapper.UserMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Service
@@ -14,17 +16,21 @@ public class UserServiceJpa implements IUserService {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private UserMapper userMapper;
+
     @Override
-    public User create(User user) {
+    public User create(UserRequestDto dto) {
+        User user = userMapper.toEntity(dto);
         return userRepository.save(user);
     }
 
     @Override
-    public User update(Long id, User user) {
+    public User update(Long id, UserRequestDto dto) {
         User existing = userRepository.findById(id)
                 .orElseThrow(() -> new RecordNotFoundException("User not found"));
-        user.setId(existing.getId());
-        return userRepository.save(user);
+        userMapper.applyToEntity(dto, existing);
+        return userRepository.save(existing);
     }
 
     @Override

--- a/src/main/java/com/ahumadamob/todolist/service/jpa/UserServiceJpa.java
+++ b/src/main/java/com/ahumadamob/todolist/service/jpa/UserServiceJpa.java
@@ -11,12 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 @Service
 public class UserServiceJpa implements IUserService {
 
-    private final UserRepository userRepository;
-
     @Autowired
-    public UserServiceJpa(UserRepository userRepository) {
-        this.userRepository = userRepository;
-    }
+    private UserRepository userRepository;
 
     @Override
     public User create(User user) {

--- a/src/main/java/com/ahumadamob/todolist/service/jpa/UserServiceJpa.java
+++ b/src/main/java/com/ahumadamob/todolist/service/jpa/UserServiceJpa.java
@@ -1,0 +1,48 @@
+package com.ahumadamob.todolist.service.jpa;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import com.ahumadamob.todolist.entity.User;
+import com.ahumadamob.todolist.repository.UserRepository;
+import com.ahumadamob.todolist.service.IUserService;
+import com.ahumadamob.todolist.exception.RecordNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Service
+public class UserServiceJpa implements IUserService {
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public UserServiceJpa(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public User create(User user) {
+        return userRepository.save(user);
+    }
+
+    @Override
+    public User update(Long id, User user) {
+        User existing = userRepository.findById(id)
+                .orElseThrow(() -> new RecordNotFoundException("User not found"));
+        user.setId(existing.getId());
+        return userRepository.save(user);
+    }
+
+    @Override
+    public List<User> findAll() {
+        return userRepository.findAll();
+    }
+
+    @Override
+    public User findById(Long id) {
+        return userRepository.findById(id).orElse(null);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        userRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- split service interfaces into `create` and `update`
- throw `RecordNotFoundException` when updating missing records
- adjust JPA service implementations
- use the new service methods in controllers

## Testing
- `bash ./mvnw -q test` *(fails: could not download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6844c0c71ba0832f936b7d0f2d73b467