### PR TITLE
Enable CORS for Angular front-end

### DIFF
--- a/src/main/java/com/ahumadamob/todolist/config/CorsConfig.java
+++ b/src/main/java/com/ahumadamob/todolist/config/CorsConfig.java
@@ -1,0 +1,23 @@
+package com.ahumadamob.todolist.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:4200")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*");
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- configure Web MVC to allow cross-origin requests from `http://localhost:4200`

## Testing
- `./mvnw -q test` *(fails: unable to download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6844f95e0bfc832fb6b1f3061ef057a7