### PR TITLE
Implement detailed error responses

### DIFF
--- a/src/main/java/com/ahumadamob/todolist/controller/GroupController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/GroupController.java
@@ -48,7 +48,7 @@ public class GroupController {
     public ResponseEntity<?> findById(@PathVariable Long id) {
         Group group = groupService.findById(id);
         if (group == null) {
-            ErrorDetailDto detail = new ErrorDetailDto(null, "Grupo no encontrado");
+            ErrorDetailDto detail = new ErrorDetailDto("groupId", "Grupo no encontrado");
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(new ErrorResponseDto(Collections.singletonList(detail)));
         }

--- a/src/main/java/com/ahumadamob/todolist/controller/GroupController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/GroupController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.ahumadamob.todolist.dto.ErrorDetailDto;
 import com.ahumadamob.todolist.dto.ErrorResponseDto;
 import com.ahumadamob.todolist.dto.SuccessResponseDto;
 import com.ahumadamob.todolist.dto.GroupRequestDto;
@@ -47,8 +48,9 @@ public class GroupController {
     public ResponseEntity<?> findById(@PathVariable Long id) {
         Group group = groupService.findById(id);
         if (group == null) {
+            ErrorDetailDto detail = new ErrorDetailDto(null, "Grupo no encontrado");
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new ErrorResponseDto(Collections.singletonList("Grupo no encontrado")));
+                    .body(new ErrorResponseDto(Collections.singletonList(detail)));
         }
         return ResponseEntity.ok(new SuccessResponseDto<>("Group found", groupMapper.toDto(group)));
     }

--- a/src/main/java/com/ahumadamob/todolist/controller/UserController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/UserController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.ahumadamob.todolist.dto.ErrorDetailDto;
 import com.ahumadamob.todolist.dto.ErrorResponseDto;
 import com.ahumadamob.todolist.dto.SuccessResponseDto;
 import com.ahumadamob.todolist.dto.UserRequestDto;
@@ -47,8 +48,9 @@ public class UserController {
     public ResponseEntity<?> findById(@PathVariable Long id) {
         User user = userService.findById(id);
         if (user == null) {
+            ErrorDetailDto detail = new ErrorDetailDto(null, "Usuario no encontrado");
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new ErrorResponseDto(Collections.singletonList("Usuario no encontrado")));
+                    .body(new ErrorResponseDto(Collections.singletonList(detail)));
         }
         return ResponseEntity.ok(new SuccessResponseDto<>("User found", userMapper.toDto(user)));
     }

--- a/src/main/java/com/ahumadamob/todolist/controller/UserController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/UserController.java
@@ -48,7 +48,7 @@ public class UserController {
     public ResponseEntity<?> findById(@PathVariable Long id) {
         User user = userService.findById(id);
         if (user == null) {
-            ErrorDetailDto detail = new ErrorDetailDto(null, "Usuario no encontrado");
+            ErrorDetailDto detail = new ErrorDetailDto("userId", "Usuario no encontrado");
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(new ErrorResponseDto(Collections.singletonList(detail)));
         }

--- a/src/main/java/com/ahumadamob/todolist/dto/ErrorDetailDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/ErrorDetailDto.java
@@ -1,0 +1,34 @@
+package com.ahumadamob.todolist.dto;
+
+/**
+ * DTO representing an individual error detail.
+ * Contains the field associated with the error (if any) and the message.
+ */
+public class ErrorDetailDto {
+    private String field;
+    private String value;
+
+    public ErrorDetailDto() {
+    }
+
+    public ErrorDetailDto(String field, String value) {
+        this.field = field;
+        this.value = value;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public void setField(String field) {
+        this.field = field;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/dto/ErrorResponseDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/ErrorResponseDto.java
@@ -1,25 +1,26 @@
 package com.ahumadamob.todolist.dto;
 
 import java.util.List;
+import com.ahumadamob.todolist.dto.ErrorDetailDto;
 
 /**
  * Simple DTO representing an error response with a list of messages.
  */
 public class ErrorResponseDto {
-    private List<String> messages;
+    private List<ErrorDetailDto> messages;
 
     public ErrorResponseDto() {
     }
 
-    public ErrorResponseDto(List<String> messages) {
+    public ErrorResponseDto(List<ErrorDetailDto> messages) {
         this.messages = messages;
     }
 
-    public List<String> getMessages() {
+    public List<ErrorDetailDto> getMessages() {
         return messages;
     }
 
-    public void setMessages(List<String> messages) {
+    public void setMessages(List<ErrorDetailDto> messages) {
         this.messages = messages;
     }
 }

--- a/src/main/java/com/ahumadamob/todolist/exception/RecordNotFoundException.java
+++ b/src/main/java/com/ahumadamob/todolist/exception/RecordNotFoundException.java
@@ -1,7 +1,14 @@
 package com.ahumadamob.todolist.exception;
 
 public class RecordNotFoundException extends RuntimeException {
-    public RecordNotFoundException(String message) {
+    private final String field;
+
+    public RecordNotFoundException(String field, String message) {
         super(message);
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
     }
 }

--- a/src/main/java/com/ahumadamob/todolist/exception/RestExceptionHandler.java
+++ b/src/main/java/com/ahumadamob/todolist/exception/RestExceptionHandler.java
@@ -19,7 +19,7 @@ public class RestExceptionHandler {
 
     @ExceptionHandler(RecordNotFoundException.class)
     public ResponseEntity<ErrorResponseDto> handleRecordNotFound(RecordNotFoundException ex) {
-        ErrorDetailDto detail = new ErrorDetailDto(null, ex.getMessage());
+        ErrorDetailDto detail = new ErrorDetailDto(ex.getField(), ex.getMessage());
         ErrorResponseDto dto = new ErrorResponseDto(Collections.singletonList(detail));
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(dto);
     }
@@ -42,7 +42,7 @@ public class RestExceptionHandler {
 
     @ExceptionHandler(ValidationException.class)
     public ResponseEntity<ErrorResponseDto> handleValidationException(ValidationException ex) {
-        ErrorDetailDto detail = new ErrorDetailDto(null, ex.getMessage());
+        ErrorDetailDto detail = new ErrorDetailDto(ex.getField(), ex.getMessage());
         ErrorResponseDto dto = new ErrorResponseDto(Collections.singletonList(detail));
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(dto);
     }

--- a/src/main/java/com/ahumadamob/todolist/exception/RestExceptionHandler.java
+++ b/src/main/java/com/ahumadamob/todolist/exception/RestExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import jakarta.validation.ConstraintViolationException;
 
+import com.ahumadamob.todolist.dto.ErrorDetailDto;
 import com.ahumadamob.todolist.dto.ErrorResponseDto;
 
 @RestControllerAdvice
@@ -18,29 +19,31 @@ public class RestExceptionHandler {
 
     @ExceptionHandler(RecordNotFoundException.class)
     public ResponseEntity<ErrorResponseDto> handleRecordNotFound(RecordNotFoundException ex) {
-        ErrorResponseDto dto = new ErrorResponseDto(Collections.singletonList(ex.getMessage()));
+        ErrorDetailDto detail = new ErrorDetailDto(null, ex.getMessage());
+        ErrorResponseDto dto = new ErrorResponseDto(Collections.singletonList(detail));
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(dto);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponseDto> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
-        List<String> errors = ex.getBindingResult().getFieldErrors().stream()
-                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+        List<ErrorDetailDto> errors = ex.getBindingResult().getFieldErrors().stream()
+                .map(fe -> new ErrorDetailDto(fe.getField(), fe.getDefaultMessage()))
                 .toList();
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDto(errors));
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ErrorResponseDto> handleConstraintViolation(ConstraintViolationException ex) {
-        List<String> errors = ex.getConstraintViolations().stream()
-                .map(cv -> cv.getMessage())
+        List<ErrorDetailDto> errors = ex.getConstraintViolations().stream()
+                .map(cv -> new ErrorDetailDto(cv.getPropertyPath().toString(), cv.getMessage()))
                 .toList();
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDto(errors));
     }
 
     @ExceptionHandler(ValidationException.class)
     public ResponseEntity<ErrorResponseDto> handleValidationException(ValidationException ex) {
-        ErrorResponseDto dto = new ErrorResponseDto(Collections.singletonList(ex.getMessage()));
+        ErrorDetailDto detail = new ErrorDetailDto(null, ex.getMessage());
+        ErrorResponseDto dto = new ErrorResponseDto(Collections.singletonList(detail));
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(dto);
     }
 }

--- a/src/main/java/com/ahumadamob/todolist/exception/ValidationException.java
+++ b/src/main/java/com/ahumadamob/todolist/exception/ValidationException.java
@@ -4,7 +4,14 @@ package com.ahumadamob.todolist.exception;
  * Exception thrown when validation rules are violated.
  */
 public class ValidationException extends RuntimeException {
-    public ValidationException(String message) {
+    private final String field;
+
+    public ValidationException(String field, String message) {
         super(message);
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
     }
 }

--- a/src/main/java/com/ahumadamob/todolist/mapper/UserMapper.java
+++ b/src/main/java/com/ahumadamob/todolist/mapper/UserMapper.java
@@ -29,7 +29,7 @@ public class UserMapper {
 
         if (dto.getGroupId() != null) {
             Group group = groupRepository.findById(dto.getGroupId())
-                    .orElseThrow(() -> new RecordNotFoundException("Grupo no encontrado"));
+                    .orElseThrow(() -> new RecordNotFoundException("groupId", "Grupo no encontrado"));
             user.setGroup(group);
         } else {
             user.setGroup(null);

--- a/src/main/java/com/ahumadamob/todolist/service/jpa/GroupServiceJpa.java
+++ b/src/main/java/com/ahumadamob/todolist/service/jpa/GroupServiceJpa.java
@@ -28,7 +28,7 @@ public class GroupServiceJpa implements IGroupService {
     @Override
     public Group update(Long id, GroupRequestDto dto) {
         Group existing = groupRepository.findById(id)
-                .orElseThrow(() -> new RecordNotFoundException("Grupo no encontrado"));
+                .orElseThrow(() -> new RecordNotFoundException("groupId", "Grupo no encontrado"));
         groupMapper.applyToEntity(dto, existing);
         return groupRepository.save(existing);
     }

--- a/src/main/java/com/ahumadamob/todolist/service/jpa/UserServiceJpa.java
+++ b/src/main/java/com/ahumadamob/todolist/service/jpa/UserServiceJpa.java
@@ -23,7 +23,7 @@ public class UserServiceJpa implements IUserService {
     @Override
     public User create(UserRequestDto dto) {
         if (userRepository.existsByUsername(dto.getUsername())) {
-            throw new ValidationException("El nombre de usuario ya existe");
+            throw new ValidationException("username", "El nombre de usuario ya existe");
         }
         User user = userMapper.toEntity(dto);
         return userRepository.save(user);
@@ -32,10 +32,10 @@ public class UserServiceJpa implements IUserService {
     @Override
     public User update(Long id, UserRequestDto dto) {
         User existing = userRepository.findById(id)
-                .orElseThrow(() -> new RecordNotFoundException("Usuario no encontrado"));
+                .orElseThrow(() -> new RecordNotFoundException("userId", "Usuario no encontrado"));
         if (!existing.getUsername().equals(dto.getUsername()) &&
                 userRepository.existsByUsername(dto.getUsername())) {
-            throw new ValidationException("El nombre de usuario ya existe");
+            throw new ValidationException("username", "El nombre de usuario ya existe");
         }
         userMapper.applyToEntity(dto, existing);
         return userRepository.save(existing);


### PR DESCRIPTION
## Summary
- introduce `ErrorDetailDto` with `field` and `value`
- update `ErrorResponseDto` to use `ErrorDetailDto`
- include field information in `RestExceptionHandler`
- update controllers to return new error structure

## Testing
- `mvnw -q test` *(fails: wget permission)*

------
https://chatgpt.com/codex/tasks/task_e_6845ebcf1a30832f8b5ae12e729c1f72