### PR TITLE
Add Materia entity with CRUD operations

### DIFF
--- a/src/main/java/com/ahumadamob/todolist/controller/MateriaController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/MateriaController.java
@@ -1,0 +1,77 @@
+package com.ahumadamob.todolist.controller;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ahumadamob.todolist.dto.ErrorDetailDto;
+import com.ahumadamob.todolist.dto.ErrorResponseDto;
+import com.ahumadamob.todolist.dto.MateriaRequestDto;
+import com.ahumadamob.todolist.dto.MateriaResponseDto;
+import com.ahumadamob.todolist.dto.SuccessResponseDto;
+import com.ahumadamob.todolist.entity.Materia;
+import com.ahumadamob.todolist.mapper.MateriaMapper;
+import com.ahumadamob.todolist.service.IMateriaService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/materias")
+public class MateriaController {
+    @Autowired
+    private IMateriaService materiaService;
+
+    @Autowired
+    private MateriaMapper materiaMapper;
+
+    @GetMapping
+    public ResponseEntity<SuccessResponseDto<List<MateriaResponseDto>>> findAll() {
+        List<Materia> materias = materiaService.findAll();
+        List<MateriaResponseDto> dtos = materias.stream()
+                .map(materiaMapper::toDto)
+                .toList();
+        return ResponseEntity.ok(new SuccessResponseDto<>("Materias retrieved", dtos));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> findById(@PathVariable Long id) {
+        Materia materia = materiaService.findById(id);
+        if (materia == null) {
+            ErrorDetailDto detail = new ErrorDetailDto("materiaId", "Materia no encontrada");
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ErrorResponseDto(Collections.singletonList(detail)));
+        }
+        return ResponseEntity.ok(new SuccessResponseDto<>("Materia found", materiaMapper.toDto(materia)));
+    }
+
+    @PostMapping
+    public ResponseEntity<SuccessResponseDto<MateriaResponseDto>> create(@Valid @RequestBody MateriaRequestDto dto) {
+        Materia saved = materiaService.create(dto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new SuccessResponseDto<>("Materia created", materiaMapper.toDto(saved)));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<SuccessResponseDto<MateriaResponseDto>> update(@PathVariable Long id,
+            @Valid @RequestBody MateriaRequestDto dto) {
+        Materia saved = materiaService.update(id, dto);
+        return ResponseEntity.ok(new SuccessResponseDto<>("Materia updated", materiaMapper.toDto(saved)));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<SuccessResponseDto<Void>> delete(@PathVariable Long id) {
+        materiaService.deleteById(id);
+        return ResponseEntity.ok(new SuccessResponseDto<>("Materia deleted", null));
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/dto/MateriaRefDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/MateriaRefDto.java
@@ -1,0 +1,33 @@
+package com.ahumadamob.todolist.dto;
+
+/**
+ * DTO simple para representar una materia como referencia.
+ */
+public class MateriaRefDto {
+    private Long id;
+    private String nombre;
+
+    public MateriaRefDto() {
+    }
+
+    public MateriaRefDto(Long id, String nombre) {
+        this.id = id;
+        this.nombre = nombre;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/dto/MateriaRequestDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/MateriaRequestDto.java
@@ -1,0 +1,45 @@
+package com.ahumadamob.todolist.dto;
+
+import java.util.List;
+
+/**
+ * DTO utilizado para crear o actualizar una materia.
+ */
+public class MateriaRequestDto {
+    private String nombre;
+    private Long carreraId;
+    private List<Long> correlativaIds;
+
+    public MateriaRequestDto() {
+    }
+
+    public MateriaRequestDto(String nombre, Long carreraId, List<Long> correlativaIds) {
+        this.nombre = nombre;
+        this.carreraId = carreraId;
+        this.correlativaIds = correlativaIds;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public Long getCarreraId() {
+        return carreraId;
+    }
+
+    public void setCarreraId(Long carreraId) {
+        this.carreraId = carreraId;
+    }
+
+    public List<Long> getCorrelativaIds() {
+        return correlativaIds;
+    }
+
+    public void setCorrelativaIds(List<Long> correlativaIds) {
+        this.correlativaIds = correlativaIds;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/dto/MateriaResponseDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/MateriaResponseDto.java
@@ -1,0 +1,55 @@
+package com.ahumadamob.todolist.dto;
+
+import java.util.List;
+
+/**
+ * DTO enviado al cliente para representar una materia.
+ */
+public class MateriaResponseDto {
+    private Long id;
+    private String nombre;
+    private CarreraResponseDto carrera;
+    private List<MateriaRefDto> correlativas;
+
+    public MateriaResponseDto() {
+    }
+
+    public MateriaResponseDto(Long id, String nombre, CarreraResponseDto carrera, List<MateriaRefDto> correlativas) {
+        this.id = id;
+        this.nombre = nombre;
+        this.carrera = carrera;
+        this.correlativas = correlativas;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public CarreraResponseDto getCarrera() {
+        return carrera;
+    }
+
+    public void setCarrera(CarreraResponseDto carrera) {
+        this.carrera = carrera;
+    }
+
+    public List<MateriaRefDto> getCorrelativas() {
+        return correlativas;
+    }
+
+    public void setCorrelativas(List<MateriaRefDto> correlativas) {
+        this.correlativas = correlativas;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/entity/Materia.java
+++ b/src/main/java/com/ahumadamob/todolist/entity/Materia.java
@@ -1,0 +1,78 @@
+package com.ahumadamob.todolist.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Materia {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank(message = "El nombre es obligatorio")
+    @Size(min = 3, max = 64, message = "El nombre debe tener entre 3 y 64 caracteres")
+    private String nombre;
+
+    @ManyToOne
+    @JoinColumn(name = "carrera_id")
+    private Carrera carrera;
+
+    @ManyToMany
+    @JoinTable(name = "materia_correlativa",
+        joinColumns = @JoinColumn(name = "materia_id"),
+        inverseJoinColumns = @JoinColumn(name = "correlativa_id"))
+    private List<Materia> correlativas = new ArrayList<>();
+
+    public Materia() {
+    }
+
+    public Materia(Long id, String nombre, Carrera carrera, List<Materia> correlativas) {
+        this.id = id;
+        this.nombre = nombre;
+        this.carrera = carrera;
+        this.correlativas = correlativas;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public Carrera getCarrera() {
+        return carrera;
+    }
+
+    public void setCarrera(Carrera carrera) {
+        this.carrera = carrera;
+    }
+
+    public List<Materia> getCorrelativas() {
+        return correlativas;
+    }
+
+    public void setCorrelativas(List<Materia> correlativas) {
+        this.correlativas = correlativas;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/exception/RestExceptionHandler.java
+++ b/src/main/java/com/ahumadamob/todolist/exception/RestExceptionHandler.java
@@ -2,6 +2,8 @@ package com.ahumadamob.todolist.exception;
 
 import java.util.Collections;
 import java.util.List;
+import java.sql.SQLIntegrityConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -45,5 +47,22 @@ public class RestExceptionHandler {
         ErrorDetailDto detail = new ErrorDetailDto(ex.getField(), ex.getMessage());
         ErrorResponseDto dto = new ErrorResponseDto(Collections.singletonList(detail));
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(dto);
+    }
+
+    @ExceptionHandler(SQLIntegrityConstraintViolationException.class)
+    public ResponseEntity<ErrorResponseDto> handleSqlIntegrityViolation(SQLIntegrityConstraintViolationException ex) {
+        ErrorDetailDto detail = new ErrorDetailDto("id", "El registro no puede ser eliminado porque está en uso");
+        ErrorResponseDto dto = new ErrorResponseDto(Collections.singletonList(detail));
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(dto);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponseDto> handleDataIntegrityViolation(DataIntegrityViolationException ex) {
+        if (ex.getRootCause() instanceof SQLIntegrityConstraintViolationException sqlEx) {
+            return handleSqlIntegrityViolation(sqlEx);
+        }
+        ErrorDetailDto detail = new ErrorDetailDto("id", "Violación de integridad de datos");
+        ErrorResponseDto dto = new ErrorResponseDto(Collections.singletonList(detail));
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(dto);
     }
 }

--- a/src/main/java/com/ahumadamob/todolist/mapper/MateriaMapper.java
+++ b/src/main/java/com/ahumadamob/todolist/mapper/MateriaMapper.java
@@ -1,0 +1,68 @@
+package com.ahumadamob.todolist.mapper;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.ahumadamob.todolist.dto.CarreraResponseDto;
+import com.ahumadamob.todolist.dto.MateriaRefDto;
+import com.ahumadamob.todolist.dto.MateriaRequestDto;
+import com.ahumadamob.todolist.dto.MateriaResponseDto;
+import com.ahumadamob.todolist.entity.Carrera;
+import com.ahumadamob.todolist.entity.Materia;
+import com.ahumadamob.todolist.exception.RecordNotFoundException;
+import com.ahumadamob.todolist.repository.CarreraRepository;
+import com.ahumadamob.todolist.repository.MateriaRepository;
+
+@Component
+public class MateriaMapper {
+
+    @Autowired
+    private CarreraRepository carreraRepository;
+
+    @Autowired
+    private MateriaRepository materiaRepository;
+
+    public Materia toEntity(MateriaRequestDto dto) {
+        Materia materia = new Materia();
+        applyToEntity(dto, materia);
+        return materia;
+    }
+
+    public void applyToEntity(MateriaRequestDto dto, Materia materia) {
+        materia.setNombre(dto.getNombre());
+
+        if (dto.getCarreraId() != null) {
+            Carrera carrera = carreraRepository.findById(dto.getCarreraId())
+                    .orElseThrow(() -> new RecordNotFoundException("carreraId", "Carrera no encontrada"));
+            materia.setCarrera(carrera);
+        } else {
+            materia.setCarrera(null);
+        }
+
+        if (dto.getCorrelativaIds() != null) {
+            List<Materia> correlativas = dto.getCorrelativaIds().stream()
+                    .map(id -> materiaRepository.findById(id)
+                            .orElseThrow(() -> new RecordNotFoundException("correlativaId", "Materia no encontrada")))
+                    .collect(Collectors.toList());
+            materia.setCorrelativas(correlativas);
+        } else {
+            materia.setCorrelativas(Collections.emptyList());
+        }
+    }
+
+    public MateriaResponseDto toDto(Materia materia) {
+        CarreraResponseDto carreraDto = null;
+        if (materia.getCarrera() != null) {
+            Carrera carrera = materia.getCarrera();
+            carreraDto = new CarreraResponseDto(carrera.getId(), carrera.getNombre());
+        }
+        List<MateriaRefDto> correlativas = materia.getCorrelativas().stream()
+                .map(m -> new MateriaRefDto(m.getId(), m.getNombre()))
+                .toList();
+        return new MateriaResponseDto(materia.getId(), materia.getNombre(), carreraDto, correlativas);
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/repository/MateriaRepository.java
+++ b/src/main/java/com/ahumadamob/todolist/repository/MateriaRepository.java
@@ -1,0 +1,7 @@
+package com.ahumadamob.todolist.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.ahumadamob.todolist.entity.Materia;
+
+public interface MateriaRepository extends JpaRepository<Materia, Long> {
+}

--- a/src/main/java/com/ahumadamob/todolist/service/IMateriaService.java
+++ b/src/main/java/com/ahumadamob/todolist/service/IMateriaService.java
@@ -1,0 +1,13 @@
+package com.ahumadamob.todolist.service;
+
+import java.util.List;
+import com.ahumadamob.todolist.entity.Materia;
+import com.ahumadamob.todolist.dto.MateriaRequestDto;
+
+public interface IMateriaService {
+    Materia create(MateriaRequestDto dto);
+    Materia update(Long id, MateriaRequestDto dto);
+    List<Materia> findAll();
+    Materia findById(Long id);
+    void deleteById(Long id);
+}

--- a/src/main/java/com/ahumadamob/todolist/service/jpa/MateriaServiceJpa.java
+++ b/src/main/java/com/ahumadamob/todolist/service/jpa/MateriaServiceJpa.java
@@ -1,0 +1,87 @@
+package com.ahumadamob.todolist.service.jpa;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.ahumadamob.todolist.entity.Materia;
+import com.ahumadamob.todolist.repository.MateriaRepository;
+import com.ahumadamob.todolist.service.IMateriaService;
+import com.ahumadamob.todolist.exception.RecordNotFoundException;
+import com.ahumadamob.todolist.exception.ValidationException;
+import com.ahumadamob.todolist.dto.MateriaRequestDto;
+import com.ahumadamob.todolist.mapper.MateriaMapper;
+
+@Service
+public class MateriaServiceJpa implements IMateriaService {
+
+    @Autowired
+    private MateriaRepository materiaRepository;
+
+    @Autowired
+    private MateriaMapper materiaMapper;
+
+    @Override
+    public Materia create(MateriaRequestDto dto) {
+        Materia materia = materiaMapper.toEntity(dto);
+        validateCorrelativas(materia, null);
+        return materiaRepository.save(materia);
+    }
+
+    @Override
+    public Materia update(Long id, MateriaRequestDto dto) {
+        Materia existing = materiaRepository.findById(id)
+                .orElseThrow(() -> new RecordNotFoundException("materiaId", "Materia no encontrada"));
+        materiaMapper.applyToEntity(dto, existing);
+        validateCorrelativas(existing, id);
+        return materiaRepository.save(existing);
+    }
+
+    @Override
+    public List<Materia> findAll() {
+        return materiaRepository.findAll();
+    }
+
+    @Override
+    public Materia findById(Long id) {
+        return materiaRepository.findById(id).orElse(null);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        materiaRepository.deleteById(id);
+    }
+
+    private void validateCorrelativas(Materia materia, Long id) {
+        Long targetId = id != null ? id : materia.getId();
+        for (Materia m : materia.getCorrelativas()) {
+            if (targetId != null && targetId.equals(m.getId())) {
+                throw new ValidationException("correlativaIds", "La materia no puede ser correlativa de sí misma");
+            }
+            if (createsCycle(m, targetId, new HashSet<>())) {
+                throw new ValidationException("correlativaIds", "Las materias correlativas no pueden generar ciclos");
+            }
+        }
+    }
+
+    private boolean createsCycle(Materia current, Long targetId, Set<Long> visited) {
+        if (current.getId() == null) {
+            return false;
+        }
+        if (!visited.add(current.getId())) {
+            return false;
+        }
+        if (targetId != null && current.getId().equals(targetId)) {
+            return true;
+        }
+        for (Materia sub : current.getCorrelativas()) {
+            if (createsCycle(sub, targetId, visited)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `Materia` entity with a self-referencing list of correlatives
- add repository, service interface and JPA implementation
- add DTOs and mapper for Materia
- expose CRUD endpoints via `MateriaController`

## Testing
- `mvnw -q test` *(fails: could not download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684634f92f60832f8c5dab490ae073bb