### PR TITLE
Add CRUD for Alumno and Profesor

### DIFF
--- a/src/main/java/com/ahumadamob/todolist/controller/AlumnoController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/AlumnoController.java
@@ -1,0 +1,76 @@
+package com.ahumadamob.todolist.controller;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ahumadamob.todolist.dto.AlumnoRequestDto;
+import com.ahumadamob.todolist.dto.AlumnoResponseDto;
+import com.ahumadamob.todolist.dto.ErrorDetailDto;
+import com.ahumadamob.todolist.dto.ErrorResponseDto;
+import com.ahumadamob.todolist.dto.SuccessResponseDto;
+import com.ahumadamob.todolist.entity.Alumno;
+import com.ahumadamob.todolist.mapper.AlumnoMapper;
+import com.ahumadamob.todolist.service.IAlumnoService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/alumnos")
+public class AlumnoController {
+    @Autowired
+    private IAlumnoService alumnoService;
+
+    @Autowired
+    private AlumnoMapper alumnoMapper;
+
+    @GetMapping
+    public ResponseEntity<SuccessResponseDto<List<AlumnoResponseDto>>> findAll() {
+        List<Alumno> alumnos = alumnoService.findAll();
+        List<AlumnoResponseDto> dtos = alumnos.stream()
+                .map(alumnoMapper::toDto)
+                .toList();
+        return ResponseEntity.ok(new SuccessResponseDto<>("Alumnos retrieved", dtos));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> findById(@PathVariable Long id) {
+        Alumno alumno = alumnoService.findById(id);
+        if (alumno == null) {
+            ErrorDetailDto detail = new ErrorDetailDto("alumnoId", "Alumno no encontrado");
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ErrorResponseDto(Collections.singletonList(detail)));
+        }
+        return ResponseEntity.ok(new SuccessResponseDto<>("Alumno found", alumnoMapper.toDto(alumno)));
+    }
+
+    @PostMapping
+    public ResponseEntity<SuccessResponseDto<AlumnoResponseDto>> create(@Valid @RequestBody AlumnoRequestDto dto) {
+        Alumno saved = alumnoService.create(dto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new SuccessResponseDto<>("Alumno created", alumnoMapper.toDto(saved)));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<SuccessResponseDto<AlumnoResponseDto>> update(@PathVariable Long id, @Valid @RequestBody AlumnoRequestDto dto) {
+        Alumno saved = alumnoService.update(id, dto);
+        return ResponseEntity.ok(new SuccessResponseDto<>("Alumno updated", alumnoMapper.toDto(saved)));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<SuccessResponseDto<Void>> delete(@PathVariable Long id) {
+        alumnoService.deleteById(id);
+        return ResponseEntity.ok(new SuccessResponseDto<>("Alumno deleted", null));
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/controller/ProfesorController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/ProfesorController.java
@@ -1,0 +1,76 @@
+package com.ahumadamob.todolist.controller;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ahumadamob.todolist.dto.ErrorDetailDto;
+import com.ahumadamob.todolist.dto.ErrorResponseDto;
+import com.ahumadamob.todolist.dto.ProfesorRequestDto;
+import com.ahumadamob.todolist.dto.ProfesorResponseDto;
+import com.ahumadamob.todolist.dto.SuccessResponseDto;
+import com.ahumadamob.todolist.entity.Profesor;
+import com.ahumadamob.todolist.mapper.ProfesorMapper;
+import com.ahumadamob.todolist.service.IProfesorService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/profesores")
+public class ProfesorController {
+    @Autowired
+    private IProfesorService profesorService;
+
+    @Autowired
+    private ProfesorMapper profesorMapper;
+
+    @GetMapping
+    public ResponseEntity<SuccessResponseDto<List<ProfesorResponseDto>>> findAll() {
+        List<Profesor> profesores = profesorService.findAll();
+        List<ProfesorResponseDto> dtos = profesores.stream()
+                .map(profesorMapper::toDto)
+                .toList();
+        return ResponseEntity.ok(new SuccessResponseDto<>("Profesores retrieved", dtos));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> findById(@PathVariable Long id) {
+        Profesor profesor = profesorService.findById(id);
+        if (profesor == null) {
+            ErrorDetailDto detail = new ErrorDetailDto("profesorId", "Profesor no encontrado");
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ErrorResponseDto(Collections.singletonList(detail)));
+        }
+        return ResponseEntity.ok(new SuccessResponseDto<>("Profesor found", profesorMapper.toDto(profesor)));
+    }
+
+    @PostMapping
+    public ResponseEntity<SuccessResponseDto<ProfesorResponseDto>> create(@Valid @RequestBody ProfesorRequestDto dto) {
+        Profesor saved = profesorService.create(dto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new SuccessResponseDto<>("Profesor created", profesorMapper.toDto(saved)));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<SuccessResponseDto<ProfesorResponseDto>> update(@PathVariable Long id, @Valid @RequestBody ProfesorRequestDto dto) {
+        Profesor saved = profesorService.update(id, dto);
+        return ResponseEntity.ok(new SuccessResponseDto<>("Profesor updated", profesorMapper.toDto(saved)));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<SuccessResponseDto<Void>> delete(@PathVariable Long id) {
+        profesorService.deleteById(id);
+        return ResponseEntity.ok(new SuccessResponseDto<>("Profesor deleted", null));
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/dto/AlumnoRequestDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/AlumnoRequestDto.java
@@ -1,0 +1,43 @@
+package com.ahumadamob.todolist.dto;
+
+/**
+ * DTO utilizado para crear o actualizar un alumno.
+ */
+public class AlumnoRequestDto {
+    private String nombre;
+    private String apellido;
+    private String fotoPerfil;
+
+    public AlumnoRequestDto() {
+    }
+
+    public AlumnoRequestDto(String nombre, String apellido, String fotoPerfil) {
+        this.nombre = nombre;
+        this.apellido = apellido;
+        this.fotoPerfil = fotoPerfil;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getApellido() {
+        return apellido;
+    }
+
+    public void setApellido(String apellido) {
+        this.apellido = apellido;
+    }
+
+    public String getFotoPerfil() {
+        return fotoPerfil;
+    }
+
+    public void setFotoPerfil(String fotoPerfil) {
+        this.fotoPerfil = fotoPerfil;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/dto/AlumnoResponseDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/AlumnoResponseDto.java
@@ -1,0 +1,53 @@
+package com.ahumadamob.todolist.dto;
+
+/**
+ * DTO enviado al cliente para representar un alumno.
+ */
+public class AlumnoResponseDto {
+    private Long id;
+    private String nombre;
+    private String apellido;
+    private String fotoPerfil;
+
+    public AlumnoResponseDto() {
+    }
+
+    public AlumnoResponseDto(Long id, String nombre, String apellido, String fotoPerfil) {
+        this.id = id;
+        this.nombre = nombre;
+        this.apellido = apellido;
+        this.fotoPerfil = fotoPerfil;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getApellido() {
+        return apellido;
+    }
+
+    public void setApellido(String apellido) {
+        this.apellido = apellido;
+    }
+
+    public String getFotoPerfil() {
+        return fotoPerfil;
+    }
+
+    public void setFotoPerfil(String fotoPerfil) {
+        this.fotoPerfil = fotoPerfil;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/dto/ProfesorRequestDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/ProfesorRequestDto.java
@@ -1,0 +1,43 @@
+package com.ahumadamob.todolist.dto;
+
+/**
+ * DTO utilizado para crear o actualizar un profesor.
+ */
+public class ProfesorRequestDto {
+    private String nombre;
+    private String apellido;
+    private String fotoPerfil;
+
+    public ProfesorRequestDto() {
+    }
+
+    public ProfesorRequestDto(String nombre, String apellido, String fotoPerfil) {
+        this.nombre = nombre;
+        this.apellido = apellido;
+        this.fotoPerfil = fotoPerfil;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getApellido() {
+        return apellido;
+    }
+
+    public void setApellido(String apellido) {
+        this.apellido = apellido;
+    }
+
+    public String getFotoPerfil() {
+        return fotoPerfil;
+    }
+
+    public void setFotoPerfil(String fotoPerfil) {
+        this.fotoPerfil = fotoPerfil;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/dto/ProfesorResponseDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/ProfesorResponseDto.java
@@ -1,0 +1,53 @@
+package com.ahumadamob.todolist.dto;
+
+/**
+ * DTO enviado al cliente para representar un profesor.
+ */
+public class ProfesorResponseDto {
+    private Long id;
+    private String nombre;
+    private String apellido;
+    private String fotoPerfil;
+
+    public ProfesorResponseDto() {
+    }
+
+    public ProfesorResponseDto(Long id, String nombre, String apellido, String fotoPerfil) {
+        this.id = id;
+        this.nombre = nombre;
+        this.apellido = apellido;
+        this.fotoPerfil = fotoPerfil;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getApellido() {
+        return apellido;
+    }
+
+    public void setApellido(String apellido) {
+        this.apellido = apellido;
+    }
+
+    public String getFotoPerfil() {
+        return fotoPerfil;
+    }
+
+    public void setFotoPerfil(String fotoPerfil) {
+        this.fotoPerfil = fotoPerfil;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/entity/Alumno.java
+++ b/src/main/java/com/ahumadamob/todolist/entity/Alumno.java
@@ -1,0 +1,68 @@
+package com.ahumadamob.todolist.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Entity
+public class Alumno {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank(message = "El nombre es obligatorio")
+    @Size(min = 3, max = 64, message = "El nombre debe tener entre 3 y 64 caracteres")
+    private String nombre;
+
+    @NotBlank(message = "El apellido es obligatorio")
+    @Size(min = 3, max = 64, message = "El apellido debe tener entre 3 y 64 caracteres")
+    private String apellido;
+
+    @Size(max = 255, message = "La URL de la foto es demasiado larga")
+    private String fotoPerfil;
+
+    public Alumno() {
+    }
+
+    public Alumno(Long id, String nombre, String apellido, String fotoPerfil) {
+        this.id = id;
+        this.nombre = nombre;
+        this.apellido = apellido;
+        this.fotoPerfil = fotoPerfil;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getApellido() {
+        return apellido;
+    }
+
+    public void setApellido(String apellido) {
+        this.apellido = apellido;
+    }
+
+    public String getFotoPerfil() {
+        return fotoPerfil;
+    }
+
+    public void setFotoPerfil(String fotoPerfil) {
+        this.fotoPerfil = fotoPerfil;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/entity/Profesor.java
+++ b/src/main/java/com/ahumadamob/todolist/entity/Profesor.java
@@ -1,0 +1,68 @@
+package com.ahumadamob.todolist.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Entity
+public class Profesor {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank(message = "El nombre es obligatorio")
+    @Size(min = 3, max = 64, message = "El nombre debe tener entre 3 y 64 caracteres")
+    private String nombre;
+
+    @NotBlank(message = "El apellido es obligatorio")
+    @Size(min = 3, max = 64, message = "El apellido debe tener entre 3 y 64 caracteres")
+    private String apellido;
+
+    @Size(max = 255, message = "La URL de la foto es demasiado larga")
+    private String fotoPerfil;
+
+    public Profesor() {
+    }
+
+    public Profesor(Long id, String nombre, String apellido, String fotoPerfil) {
+        this.id = id;
+        this.nombre = nombre;
+        this.apellido = apellido;
+        this.fotoPerfil = fotoPerfil;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getApellido() {
+        return apellido;
+    }
+
+    public void setApellido(String apellido) {
+        this.apellido = apellido;
+    }
+
+    public String getFotoPerfil() {
+        return fotoPerfil;
+    }
+
+    public void setFotoPerfil(String fotoPerfil) {
+        this.fotoPerfil = fotoPerfil;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/mapper/AlumnoMapper.java
+++ b/src/main/java/com/ahumadamob/todolist/mapper/AlumnoMapper.java
@@ -1,0 +1,27 @@
+package com.ahumadamob.todolist.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.ahumadamob.todolist.dto.AlumnoRequestDto;
+import com.ahumadamob.todolist.dto.AlumnoResponseDto;
+import com.ahumadamob.todolist.entity.Alumno;
+
+@Component
+public class AlumnoMapper {
+
+    public Alumno toEntity(AlumnoRequestDto dto) {
+        Alumno alumno = new Alumno();
+        applyToEntity(dto, alumno);
+        return alumno;
+    }
+
+    public void applyToEntity(AlumnoRequestDto dto, Alumno alumno) {
+        alumno.setNombre(dto.getNombre());
+        alumno.setApellido(dto.getApellido());
+        alumno.setFotoPerfil(dto.getFotoPerfil());
+    }
+
+    public AlumnoResponseDto toDto(Alumno alumno) {
+        return new AlumnoResponseDto(alumno.getId(), alumno.getNombre(), alumno.getApellido(), alumno.getFotoPerfil());
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/mapper/ProfesorMapper.java
+++ b/src/main/java/com/ahumadamob/todolist/mapper/ProfesorMapper.java
@@ -1,0 +1,27 @@
+package com.ahumadamob.todolist.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.ahumadamob.todolist.dto.ProfesorRequestDto;
+import com.ahumadamob.todolist.dto.ProfesorResponseDto;
+import com.ahumadamob.todolist.entity.Profesor;
+
+@Component
+public class ProfesorMapper {
+
+    public Profesor toEntity(ProfesorRequestDto dto) {
+        Profesor profesor = new Profesor();
+        applyToEntity(dto, profesor);
+        return profesor;
+    }
+
+    public void applyToEntity(ProfesorRequestDto dto, Profesor profesor) {
+        profesor.setNombre(dto.getNombre());
+        profesor.setApellido(dto.getApellido());
+        profesor.setFotoPerfil(dto.getFotoPerfil());
+    }
+
+    public ProfesorResponseDto toDto(Profesor profesor) {
+        return new ProfesorResponseDto(profesor.getId(), profesor.getNombre(), profesor.getApellido(), profesor.getFotoPerfil());
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/repository/AlumnoRepository.java
+++ b/src/main/java/com/ahumadamob/todolist/repository/AlumnoRepository.java
@@ -1,0 +1,7 @@
+package com.ahumadamob.todolist.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.ahumadamob.todolist.entity.Alumno;
+
+public interface AlumnoRepository extends JpaRepository<Alumno, Long> {
+}

--- a/src/main/java/com/ahumadamob/todolist/repository/ProfesorRepository.java
+++ b/src/main/java/com/ahumadamob/todolist/repository/ProfesorRepository.java
@@ -1,0 +1,7 @@
+package com.ahumadamob.todolist.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.ahumadamob.todolist.entity.Profesor;
+
+public interface ProfesorRepository extends JpaRepository<Profesor, Long> {
+}

--- a/src/main/java/com/ahumadamob/todolist/service/IAlumnoService.java
+++ b/src/main/java/com/ahumadamob/todolist/service/IAlumnoService.java
@@ -1,0 +1,13 @@
+package com.ahumadamob.todolist.service;
+
+import java.util.List;
+import com.ahumadamob.todolist.entity.Alumno;
+import com.ahumadamob.todolist.dto.AlumnoRequestDto;
+
+public interface IAlumnoService {
+    Alumno create(AlumnoRequestDto dto);
+    Alumno update(Long id, AlumnoRequestDto dto);
+    List<Alumno> findAll();
+    Alumno findById(Long id);
+    void deleteById(Long id);
+}

--- a/src/main/java/com/ahumadamob/todolist/service/IProfesorService.java
+++ b/src/main/java/com/ahumadamob/todolist/service/IProfesorService.java
@@ -1,0 +1,13 @@
+package com.ahumadamob.todolist.service;
+
+import java.util.List;
+import com.ahumadamob.todolist.entity.Profesor;
+import com.ahumadamob.todolist.dto.ProfesorRequestDto;
+
+public interface IProfesorService {
+    Profesor create(ProfesorRequestDto dto);
+    Profesor update(Long id, ProfesorRequestDto dto);
+    List<Profesor> findAll();
+    Profesor findById(Long id);
+    void deleteById(Long id);
+}

--- a/src/main/java/com/ahumadamob/todolist/service/jpa/AlumnoServiceJpa.java
+++ b/src/main/java/com/ahumadamob/todolist/service/jpa/AlumnoServiceJpa.java
@@ -1,0 +1,52 @@
+package com.ahumadamob.todolist.service.jpa;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.ahumadamob.todolist.entity.Alumno;
+import com.ahumadamob.todolist.repository.AlumnoRepository;
+import com.ahumadamob.todolist.service.IAlumnoService;
+import com.ahumadamob.todolist.exception.RecordNotFoundException;
+import com.ahumadamob.todolist.dto.AlumnoRequestDto;
+import com.ahumadamob.todolist.mapper.AlumnoMapper;
+
+@Service
+public class AlumnoServiceJpa implements IAlumnoService {
+
+    @Autowired
+    private AlumnoRepository alumnoRepository;
+
+    @Autowired
+    private AlumnoMapper alumnoMapper;
+
+    @Override
+    public Alumno create(AlumnoRequestDto dto) {
+        Alumno alumno = alumnoMapper.toEntity(dto);
+        return alumnoRepository.save(alumno);
+    }
+
+    @Override
+    public Alumno update(Long id, AlumnoRequestDto dto) {
+        Alumno existing = alumnoRepository.findById(id)
+                .orElseThrow(() -> new RecordNotFoundException("alumnoId", "Alumno no encontrado"));
+        alumnoMapper.applyToEntity(dto, existing);
+        return alumnoRepository.save(existing);
+    }
+
+    @Override
+    public List<Alumno> findAll() {
+        return alumnoRepository.findAll();
+    }
+
+    @Override
+    public Alumno findById(Long id) {
+        return alumnoRepository.findById(id).orElse(null);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        alumnoRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/service/jpa/ProfesorServiceJpa.java
+++ b/src/main/java/com/ahumadamob/todolist/service/jpa/ProfesorServiceJpa.java
@@ -1,0 +1,52 @@
+package com.ahumadamob.todolist.service.jpa;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.ahumadamob.todolist.entity.Profesor;
+import com.ahumadamob.todolist.repository.ProfesorRepository;
+import com.ahumadamob.todolist.service.IProfesorService;
+import com.ahumadamob.todolist.exception.RecordNotFoundException;
+import com.ahumadamob.todolist.dto.ProfesorRequestDto;
+import com.ahumadamob.todolist.mapper.ProfesorMapper;
+
+@Service
+public class ProfesorServiceJpa implements IProfesorService {
+
+    @Autowired
+    private ProfesorRepository profesorRepository;
+
+    @Autowired
+    private ProfesorMapper profesorMapper;
+
+    @Override
+    public Profesor create(ProfesorRequestDto dto) {
+        Profesor profesor = profesorMapper.toEntity(dto);
+        return profesorRepository.save(profesor);
+    }
+
+    @Override
+    public Profesor update(Long id, ProfesorRequestDto dto) {
+        Profesor existing = profesorRepository.findById(id)
+                .orElseThrow(() -> new RecordNotFoundException("profesorId", "Profesor no encontrado"));
+        profesorMapper.applyToEntity(dto, existing);
+        return profesorRepository.save(existing);
+    }
+
+    @Override
+    public List<Profesor> findAll() {
+        return profesorRepository.findAll();
+    }
+
+    @Override
+    public Profesor findById(Long id) {
+        return profesorRepository.findById(id).orElse(null);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        profesorRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `Alumno` and `Profesor` entities
- add DTOs, mappers, repositories and services for both
- expose `/alumnos` and `/profesores` REST endpoints

## Testing
- `mvnw -q test` *(fails: Unable to download maven distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68464cd0b11c832f9812b38811861c51