### PR TITLE
Add academic year and course entities with CRUD

### DIFF
--- a/src/main/java/com/ahumadamob/todolist/controller/AnioAcademicoController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/AnioAcademicoController.java
@@ -1,0 +1,77 @@
+package com.ahumadamob.todolist.controller;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ahumadamob.todolist.dto.ErrorDetailDto;
+import com.ahumadamob.todolist.dto.ErrorResponseDto;
+import com.ahumadamob.todolist.dto.AnioAcademicoRequestDto;
+import com.ahumadamob.todolist.dto.AnioAcademicoResponseDto;
+import com.ahumadamob.todolist.dto.SuccessResponseDto;
+import com.ahumadamob.todolist.entity.AnioAcademico;
+import com.ahumadamob.todolist.mapper.AnioAcademicoMapper;
+import com.ahumadamob.todolist.service.IAnioAcademicoService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/anios-academicos")
+public class AnioAcademicoController {
+    @Autowired
+    private IAnioAcademicoService anioAcademicoService;
+
+    @Autowired
+    private AnioAcademicoMapper anioAcademicoMapper;
+
+    @GetMapping
+    public ResponseEntity<SuccessResponseDto<List<AnioAcademicoResponseDto>>> findAll() {
+        List<AnioAcademico> anios = anioAcademicoService.findAll();
+        List<AnioAcademicoResponseDto> dtos = anios.stream()
+                .map(anioAcademicoMapper::toDto)
+                .toList();
+        return ResponseEntity.ok(new SuccessResponseDto<>("Años académicos retrieved", dtos));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> findById(@PathVariable Long id) {
+        AnioAcademico anio = anioAcademicoService.findById(id);
+        if (anio == null) {
+            ErrorDetailDto detail = new ErrorDetailDto("anioAcademicoId", "Año académico no encontrado");
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ErrorResponseDto(Collections.singletonList(detail)));
+        }
+        return ResponseEntity.ok(new SuccessResponseDto<>("Año académico found", anioAcademicoMapper.toDto(anio)));
+    }
+
+    @PostMapping
+    public ResponseEntity<SuccessResponseDto<AnioAcademicoResponseDto>> create(@Valid @RequestBody AnioAcademicoRequestDto dto) {
+        AnioAcademico saved = anioAcademicoService.create(dto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new SuccessResponseDto<>("Año académico created", anioAcademicoMapper.toDto(saved)));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<SuccessResponseDto<AnioAcademicoResponseDto>> update(@PathVariable Long id,
+            @Valid @RequestBody AnioAcademicoRequestDto dto) {
+        AnioAcademico saved = anioAcademicoService.update(id, dto);
+        return ResponseEntity.ok(new SuccessResponseDto<>("Año académico updated", anioAcademicoMapper.toDto(saved)));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<SuccessResponseDto<Void>> delete(@PathVariable Long id) {
+        anioAcademicoService.deleteById(id);
+        return ResponseEntity.ok(new SuccessResponseDto<>("Año académico deleted", null));
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/controller/CursoController.java
+++ b/src/main/java/com/ahumadamob/todolist/controller/CursoController.java
@@ -1,0 +1,77 @@
+package com.ahumadamob.todolist.controller;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ahumadamob.todolist.dto.ErrorDetailDto;
+import com.ahumadamob.todolist.dto.ErrorResponseDto;
+import com.ahumadamob.todolist.dto.CursoRequestDto;
+import com.ahumadamob.todolist.dto.CursoResponseDto;
+import com.ahumadamob.todolist.dto.SuccessResponseDto;
+import com.ahumadamob.todolist.entity.Curso;
+import com.ahumadamob.todolist.mapper.CursoMapper;
+import com.ahumadamob.todolist.service.ICursoService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/cursos")
+public class CursoController {
+    @Autowired
+    private ICursoService cursoService;
+
+    @Autowired
+    private CursoMapper cursoMapper;
+
+    @GetMapping
+    public ResponseEntity<SuccessResponseDto<List<CursoResponseDto>>> findAll() {
+        List<Curso> cursos = cursoService.findAll();
+        List<CursoResponseDto> dtos = cursos.stream()
+                .map(cursoMapper::toDto)
+                .toList();
+        return ResponseEntity.ok(new SuccessResponseDto<>("Cursos retrieved", dtos));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> findById(@PathVariable Long id) {
+        Curso curso = cursoService.findById(id);
+        if (curso == null) {
+            ErrorDetailDto detail = new ErrorDetailDto("cursoId", "Curso no encontrado");
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ErrorResponseDto(Collections.singletonList(detail)));
+        }
+        return ResponseEntity.ok(new SuccessResponseDto<>("Curso found", cursoMapper.toDto(curso)));
+    }
+
+    @PostMapping
+    public ResponseEntity<SuccessResponseDto<CursoResponseDto>> create(@Valid @RequestBody CursoRequestDto dto) {
+        Curso saved = cursoService.create(dto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new SuccessResponseDto<>("Curso created", cursoMapper.toDto(saved)));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<SuccessResponseDto<CursoResponseDto>> update(@PathVariable Long id,
+            @Valid @RequestBody CursoRequestDto dto) {
+        Curso saved = cursoService.update(id, dto);
+        return ResponseEntity.ok(new SuccessResponseDto<>("Curso updated", cursoMapper.toDto(saved)));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<SuccessResponseDto<Void>> delete(@PathVariable Long id) {
+        cursoService.deleteById(id);
+        return ResponseEntity.ok(new SuccessResponseDto<>("Curso deleted", null));
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/dto/AnioAcademicoRequestDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/AnioAcademicoRequestDto.java
@@ -1,0 +1,33 @@
+package com.ahumadamob.todolist.dto;
+
+/**
+ * DTO utilizado para crear o actualizar un año académico.
+ */
+public class AnioAcademicoRequestDto {
+    private Integer anio;
+    private Boolean activo;
+
+    public AnioAcademicoRequestDto() {
+    }
+
+    public AnioAcademicoRequestDto(Integer anio, Boolean activo) {
+        this.anio = anio;
+        this.activo = activo;
+    }
+
+    public Integer getAnio() {
+        return anio;
+    }
+
+    public void setAnio(Integer anio) {
+        this.anio = anio;
+    }
+
+    public Boolean getActivo() {
+        return activo;
+    }
+
+    public void setActivo(Boolean activo) {
+        this.activo = activo;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/dto/AnioAcademicoResponseDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/AnioAcademicoResponseDto.java
@@ -1,0 +1,43 @@
+package com.ahumadamob.todolist.dto;
+
+/**
+ * DTO enviado al cliente para representar un año académico.
+ */
+public class AnioAcademicoResponseDto {
+    private Long id;
+    private Integer anio;
+    private Boolean activo;
+
+    public AnioAcademicoResponseDto() {
+    }
+
+    public AnioAcademicoResponseDto(Long id, Integer anio, Boolean activo) {
+        this.id = id;
+        this.anio = anio;
+        this.activo = activo;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Integer getAnio() {
+        return anio;
+    }
+
+    public void setAnio(Integer anio) {
+        this.anio = anio;
+    }
+
+    public Boolean getActivo() {
+        return activo;
+    }
+
+    public void setActivo(Boolean activo) {
+        this.activo = activo;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/dto/CursoRequestDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/CursoRequestDto.java
@@ -1,0 +1,43 @@
+package com.ahumadamob.todolist.dto;
+
+/**
+ * DTO utilizado para crear o actualizar un curso.
+ */
+public class CursoRequestDto {
+    private Integer anioCursado;
+    private String division;
+    private Long anioAcademicoId;
+
+    public CursoRequestDto() {
+    }
+
+    public CursoRequestDto(Integer anioCursado, String division, Long anioAcademicoId) {
+        this.anioCursado = anioCursado;
+        this.division = division;
+        this.anioAcademicoId = anioAcademicoId;
+    }
+
+    public Integer getAnioCursado() {
+        return anioCursado;
+    }
+
+    public void setAnioCursado(Integer anioCursado) {
+        this.anioCursado = anioCursado;
+    }
+
+    public String getDivision() {
+        return division;
+    }
+
+    public void setDivision(String division) {
+        this.division = division;
+    }
+
+    public Long getAnioAcademicoId() {
+        return anioAcademicoId;
+    }
+
+    public void setAnioAcademicoId(Long anioAcademicoId) {
+        this.anioAcademicoId = anioAcademicoId;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/dto/CursoResponseDto.java
+++ b/src/main/java/com/ahumadamob/todolist/dto/CursoResponseDto.java
@@ -1,0 +1,53 @@
+package com.ahumadamob.todolist.dto;
+
+/**
+ * DTO enviado al cliente para representar un curso.
+ */
+public class CursoResponseDto {
+    private Long id;
+    private Integer anioCursado;
+    private String division;
+    private AnioAcademicoResponseDto anioAcademico;
+
+    public CursoResponseDto() {
+    }
+
+    public CursoResponseDto(Long id, Integer anioCursado, String division, AnioAcademicoResponseDto anioAcademico) {
+        this.id = id;
+        this.anioCursado = anioCursado;
+        this.division = division;
+        this.anioAcademico = anioAcademico;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Integer getAnioCursado() {
+        return anioCursado;
+    }
+
+    public void setAnioCursado(Integer anioCursado) {
+        this.anioCursado = anioCursado;
+    }
+
+    public String getDivision() {
+        return division;
+    }
+
+    public void setDivision(String division) {
+        this.division = division;
+    }
+
+    public AnioAcademicoResponseDto getAnioAcademico() {
+        return anioAcademico;
+    }
+
+    public void setAnioAcademico(AnioAcademicoResponseDto anioAcademico) {
+        this.anioAcademico = anioAcademico;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/entity/AnioAcademico.java
+++ b/src/main/java/com/ahumadamob/todolist/entity/AnioAcademico.java
@@ -1,0 +1,66 @@
+package com.ahumadamob.todolist.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.util.List;
+
+@Entity
+@Table(name = "anio_academico")
+public class AnioAcademico {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Integer anio;
+
+    private Boolean activo;
+
+    @OneToMany(mappedBy = "anioAcademico")
+    private List<Curso> cursos;
+
+    public AnioAcademico() {
+    }
+
+    public AnioAcademico(Long id, Integer anio, Boolean activo) {
+        this.id = id;
+        this.anio = anio;
+        this.activo = activo;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Integer getAnio() {
+        return anio;
+    }
+
+    public void setAnio(Integer anio) {
+        this.anio = anio;
+    }
+
+    public Boolean getActivo() {
+        return activo;
+    }
+
+    public void setActivo(Boolean activo) {
+        this.activo = activo;
+    }
+
+    public List<Curso> getCursos() {
+        return cursos;
+    }
+
+    public void setCursos(List<Curso> cursos) {
+        this.cursos = cursos;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/entity/Curso.java
+++ b/src/main/java/com/ahumadamob/todolist/entity/Curso.java
@@ -1,0 +1,67 @@
+package com.ahumadamob.todolist.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "curso")
+public class Curso {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Integer anioCursado;
+
+    private String division;
+
+    @ManyToOne
+    @JoinColumn(name = "anio_academico_id")
+    private AnioAcademico anioAcademico;
+
+    public Curso() {
+    }
+
+    public Curso(Long id, Integer anioCursado, String division, AnioAcademico anioAcademico) {
+        this.id = id;
+        this.anioCursado = anioCursado;
+        this.division = division;
+        this.anioAcademico = anioAcademico;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Integer getAnioCursado() {
+        return anioCursado;
+    }
+
+    public void setAnioCursado(Integer anioCursado) {
+        this.anioCursado = anioCursado;
+    }
+
+    public String getDivision() {
+        return division;
+    }
+
+    public void setDivision(String division) {
+        this.division = division;
+    }
+
+    public AnioAcademico getAnioAcademico() {
+        return anioAcademico;
+    }
+
+    public void setAnioAcademico(AnioAcademico anioAcademico) {
+        this.anioAcademico = anioAcademico;
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/mapper/AnioAcademicoMapper.java
+++ b/src/main/java/com/ahumadamob/todolist/mapper/AnioAcademicoMapper.java
@@ -1,0 +1,26 @@
+package com.ahumadamob.todolist.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.ahumadamob.todolist.dto.AnioAcademicoRequestDto;
+import com.ahumadamob.todolist.dto.AnioAcademicoResponseDto;
+import com.ahumadamob.todolist.entity.AnioAcademico;
+
+@Component
+public class AnioAcademicoMapper {
+
+    public AnioAcademico toEntity(AnioAcademicoRequestDto dto) {
+        AnioAcademico anio = new AnioAcademico();
+        applyToEntity(dto, anio);
+        return anio;
+    }
+
+    public void applyToEntity(AnioAcademicoRequestDto dto, AnioAcademico anio) {
+        anio.setAnio(dto.getAnio());
+        anio.setActivo(dto.getActivo());
+    }
+
+    public AnioAcademicoResponseDto toDto(AnioAcademico anio) {
+        return new AnioAcademicoResponseDto(anio.getId(), anio.getAnio(), anio.getActivo());
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/mapper/CursoMapper.java
+++ b/src/main/java/com/ahumadamob/todolist/mapper/CursoMapper.java
@@ -1,0 +1,47 @@
+package com.ahumadamob.todolist.mapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.ahumadamob.todolist.dto.AnioAcademicoResponseDto;
+import com.ahumadamob.todolist.dto.CursoRequestDto;
+import com.ahumadamob.todolist.dto.CursoResponseDto;
+import com.ahumadamob.todolist.entity.AnioAcademico;
+import com.ahumadamob.todolist.entity.Curso;
+import com.ahumadamob.todolist.exception.RecordNotFoundException;
+import com.ahumadamob.todolist.repository.AnioAcademicoRepository;
+
+@Component
+public class CursoMapper {
+
+    @Autowired
+    private AnioAcademicoRepository anioAcademicoRepository;
+
+    public Curso toEntity(CursoRequestDto dto) {
+        Curso curso = new Curso();
+        applyToEntity(dto, curso);
+        return curso;
+    }
+
+    public void applyToEntity(CursoRequestDto dto, Curso curso) {
+        curso.setAnioCursado(dto.getAnioCursado());
+        curso.setDivision(dto.getDivision());
+
+        if (dto.getAnioAcademicoId() != null) {
+            AnioAcademico anio = anioAcademicoRepository.findById(dto.getAnioAcademicoId())
+                    .orElseThrow(() -> new RecordNotFoundException("anioAcademicoId", "Año académico no encontrado"));
+            curso.setAnioAcademico(anio);
+        } else {
+            curso.setAnioAcademico(null);
+        }
+    }
+
+    public CursoResponseDto toDto(Curso curso) {
+        AnioAcademicoResponseDto anioDto = null;
+        if (curso.getAnioAcademico() != null) {
+            AnioAcademico anio = curso.getAnioAcademico();
+            anioDto = new AnioAcademicoResponseDto(anio.getId(), anio.getAnio(), anio.getActivo());
+        }
+        return new CursoResponseDto(curso.getId(), curso.getAnioCursado(), curso.getDivision(), anioDto);
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/repository/AnioAcademicoRepository.java
+++ b/src/main/java/com/ahumadamob/todolist/repository/AnioAcademicoRepository.java
@@ -1,0 +1,7 @@
+package com.ahumadamob.todolist.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.ahumadamob.todolist.entity.AnioAcademico;
+
+public interface AnioAcademicoRepository extends JpaRepository<AnioAcademico, Long> {
+}

--- a/src/main/java/com/ahumadamob/todolist/repository/CursoRepository.java
+++ b/src/main/java/com/ahumadamob/todolist/repository/CursoRepository.java
@@ -1,0 +1,7 @@
+package com.ahumadamob.todolist.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.ahumadamob.todolist.entity.Curso;
+
+public interface CursoRepository extends JpaRepository<Curso, Long> {
+}

--- a/src/main/java/com/ahumadamob/todolist/service/IAnioAcademicoService.java
+++ b/src/main/java/com/ahumadamob/todolist/service/IAnioAcademicoService.java
@@ -1,0 +1,13 @@
+package com.ahumadamob.todolist.service;
+
+import java.util.List;
+import com.ahumadamob.todolist.entity.AnioAcademico;
+import com.ahumadamob.todolist.dto.AnioAcademicoRequestDto;
+
+public interface IAnioAcademicoService {
+    AnioAcademico create(AnioAcademicoRequestDto dto);
+    AnioAcademico update(Long id, AnioAcademicoRequestDto dto);
+    List<AnioAcademico> findAll();
+    AnioAcademico findById(Long id);
+    void deleteById(Long id);
+}

--- a/src/main/java/com/ahumadamob/todolist/service/ICursoService.java
+++ b/src/main/java/com/ahumadamob/todolist/service/ICursoService.java
@@ -1,0 +1,13 @@
+package com.ahumadamob.todolist.service;
+
+import java.util.List;
+import com.ahumadamob.todolist.entity.Curso;
+import com.ahumadamob.todolist.dto.CursoRequestDto;
+
+public interface ICursoService {
+    Curso create(CursoRequestDto dto);
+    Curso update(Long id, CursoRequestDto dto);
+    List<Curso> findAll();
+    Curso findById(Long id);
+    void deleteById(Long id);
+}

--- a/src/main/java/com/ahumadamob/todolist/service/jpa/AnioAcademicoServiceJpa.java
+++ b/src/main/java/com/ahumadamob/todolist/service/jpa/AnioAcademicoServiceJpa.java
@@ -1,0 +1,51 @@
+package com.ahumadamob.todolist.service.jpa;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.ahumadamob.todolist.entity.AnioAcademico;
+import com.ahumadamob.todolist.repository.AnioAcademicoRepository;
+import com.ahumadamob.todolist.service.IAnioAcademicoService;
+import com.ahumadamob.todolist.exception.RecordNotFoundException;
+import com.ahumadamob.todolist.dto.AnioAcademicoRequestDto;
+import com.ahumadamob.todolist.mapper.AnioAcademicoMapper;
+
+@Service
+public class AnioAcademicoServiceJpa implements IAnioAcademicoService {
+
+    @Autowired
+    private AnioAcademicoRepository anioAcademicoRepository;
+
+    @Autowired
+    private AnioAcademicoMapper anioAcademicoMapper;
+
+    @Override
+    public AnioAcademico create(AnioAcademicoRequestDto dto) {
+        AnioAcademico anio = anioAcademicoMapper.toEntity(dto);
+        return anioAcademicoRepository.save(anio);
+    }
+
+    @Override
+    public AnioAcademico update(Long id, AnioAcademicoRequestDto dto) {
+        AnioAcademico existing = anioAcademicoRepository.findById(id)
+                .orElseThrow(() -> new RecordNotFoundException("anioAcademicoId", "Año académico no encontrado"));
+        anioAcademicoMapper.applyToEntity(dto, existing);
+        return anioAcademicoRepository.save(existing);
+    }
+
+    @Override
+    public List<AnioAcademico> findAll() {
+        return anioAcademicoRepository.findAll();
+    }
+
+    @Override
+    public AnioAcademico findById(Long id) {
+        return anioAcademicoRepository.findById(id).orElse(null);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        anioAcademicoRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/ahumadamob/todolist/service/jpa/CursoServiceJpa.java
+++ b/src/main/java/com/ahumadamob/todolist/service/jpa/CursoServiceJpa.java
@@ -1,0 +1,51 @@
+package com.ahumadamob.todolist.service.jpa;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.ahumadamob.todolist.entity.Curso;
+import com.ahumadamob.todolist.repository.CursoRepository;
+import com.ahumadamob.todolist.service.ICursoService;
+import com.ahumadamob.todolist.exception.RecordNotFoundException;
+import com.ahumadamob.todolist.dto.CursoRequestDto;
+import com.ahumadamob.todolist.mapper.CursoMapper;
+
+@Service
+public class CursoServiceJpa implements ICursoService {
+
+    @Autowired
+    private CursoRepository cursoRepository;
+
+    @Autowired
+    private CursoMapper cursoMapper;
+
+    @Override
+    public Curso create(CursoRequestDto dto) {
+        Curso curso = cursoMapper.toEntity(dto);
+        return cursoRepository.save(curso);
+    }
+
+    @Override
+    public Curso update(Long id, CursoRequestDto dto) {
+        Curso existing = cursoRepository.findById(id)
+                .orElseThrow(() -> new RecordNotFoundException("cursoId", "Curso no encontrado"));
+        cursoMapper.applyToEntity(dto, existing);
+        return cursoRepository.save(existing);
+    }
+
+    @Override
+    public List<Curso> findAll() {
+        return cursoRepository.findAll();
+    }
+
+    @Override
+    public Curso findById(Long id) {
+        return cursoRepository.findById(id).orElse(null);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        cursoRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `AnioAcademico` and `Curso` entities
- create request and response DTOs for both entities
- add mappers and repositories
- expose services and controllers for CRUD operations

## Testing
- `./mvnw -q test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684a11da4310832fb2dcee97bf85023c